### PR TITLE
Refactor macros into generics

### DIFF
--- a/packages/server/src/api/bo.rs
+++ b/packages/server/src/api/bo.rs
@@ -15,7 +15,7 @@ use bson::doc;
 
 #[get("/courses")]
 pub async fn get_all_courses(_: Admin, db: Data<Db>) -> Result<HttpResponse, AppError> {
-    db.get_all_courses()
+    db.get_all::<Course>()
         .await
         .map(|courses| HttpResponse::Ok().json(courses))
 }
@@ -26,7 +26,7 @@ pub async fn get_course_by_id(
     id: Path<String>,
     db: Data<Db>,
 ) -> Result<HttpResponse, AppError> {
-    db.get_course_by_id(&id)
+    db.get::<Course>(id.as_str())
         .await
         .map(|course| HttpResponse::Ok().json(course))
 }
@@ -40,7 +40,7 @@ pub async fn create_or_update_course(
 ) -> Result<HttpResponse, AppError> {
     let course_doc = bson::to_document(&course).map_err(|e| AppError::Bson(e.to_string()))?;
     let document = doc! {"$setOnInsert" : course_doc};
-    db.find_and_update_course(&id, document)
+    db.update::<Course>(id.as_str(), document)
         .await
         .map(|course| HttpResponse::Ok().json(course))
 }
@@ -51,7 +51,7 @@ pub async fn delete_course(
     id: Path<String>,
     db: Data<Db>,
 ) -> Result<HttpResponse, AppError> {
-    db.delete_course(&id)
+    db.delete::<Course>(id.as_str())
         .await
         .map(|_| HttpResponse::Ok().finish())
 }
@@ -67,7 +67,7 @@ pub async fn get_catalog_by_id(
     db: Data<Db>,
 ) -> Result<HttpResponse, AppError> {
     let obj_id = bson::oid::ObjectId::from_str(&id).map_err(|e| AppError::Bson(e.to_string()))?;
-    db.get_catalog_by_id(&obj_id)
+    db.get::<Catalog>(&obj_id)
         .await
         .map(|course| HttpResponse::Ok().json(course))
 }
@@ -83,7 +83,7 @@ pub async fn create_or_update_catalog(
     let obj_id = bson::oid::ObjectId::from_str(&id).map_err(|e| AppError::Bson(e.to_string()))?;
     let catalog_doc = bson::to_document(&catalog).map_err(|e| AppError::Bson(e.to_string()))?;
     let document = doc! {"$setOnInsert" : catalog_doc};
-    db.find_and_update_catalog(&obj_id, document)
+    db.update::<Catalog>(&obj_id, document)
         .await
         .map(|catalog| HttpResponse::Ok().json(catalog))
 }

--- a/packages/server/src/core/tests.rs
+++ b/packages/server/src/core/tests.rs
@@ -7,7 +7,7 @@ use crate::db::Db;
 use crate::resources::catalog::Catalog;
 use crate::resources::course::CourseState::NotComplete;
 use crate::resources::course::Grade::Numeric;
-use crate::resources::course::{self, Course, CourseState, CourseStatus, Grade};
+use crate::resources::course::{self, Course, CourseState, CourseStatus, Grade, Malags};
 use actix_rt::test;
 use dotenv::dotenv;
 use lazy_static::lazy_static;
@@ -434,7 +434,7 @@ async fn get_catalog(catalog: &str) -> Catalog {
     dotenv().ok();
     let db = Db::new().await;
     let obj_id = bson::oid::ObjectId::from_str(catalog).expect("failed to create oid");
-    db.get_catalog_by_id(&obj_id)
+    db.get::<Catalog>(&obj_id)
         .await
         .expect("failed to get catalog")
 }
@@ -443,10 +443,13 @@ async fn run_degree_status(mut degree_status: DegreeStatus, catalog: Catalog) ->
     dotenv().ok();
     let db = Db::new().await;
     let vec_courses = db
-        .get_all_courses()
+        .get_all::<Course>()
         .await
         .expect("failed to get all courses");
-    let malag_courses = db.get_all_malags().await.expect("failed to get all malags")[0]
+    let malag_courses = db
+        .get_all::<Malags>()
+        .await
+        .expect("failed to get all malags")[0]
         .malag_list
         .clone();
     degree_status.compute(catalog, course::vec_to_map(vec_courses), malag_courses);

--- a/packages/server/src/db/mod.rs
+++ b/packages/server/src/db/mod.rs
@@ -29,3 +29,21 @@ impl From<Client> for Db {
         Self { client }
     }
 }
+
+pub enum FilterType {
+    Regex,
+    In,
+}
+
+impl AsRef<str> for FilterType {
+    fn as_ref(&self) -> &str {
+        match self {
+            FilterType::Regex => "$regex",
+            FilterType::In => "$in",
+        }
+    }
+}
+
+pub trait CollectionName {
+    fn collection_name() -> &'static str;
+}

--- a/packages/server/src/db/services.rs
+++ b/packages/server/src/db/services.rs
@@ -1,248 +1,99 @@
 use crate::config::CONFIG;
 use crate::error::AppError;
-use crate::resources::admin::Admin;
-use crate::resources::catalog::{Catalog, DisplayCatalog};
-use crate::resources::course::{Course, Malags};
-use crate::resources::user::User;
-use bson::oid::ObjectId;
 pub use bson::{doc, Bson, Document};
 use futures_util::TryStreamExt;
 use mongodb::options::{FindOneAndUpdateOptions, ReturnDocument, UpdateModifications};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
-use super::Db;
-
-macro_rules! impl_get {
-    (
-        fn_name=$fn_name:ident,
-        db_item=$db_item:ty,
-        db_key_type=$db_key_type:ty
-    ) => {
-        pub async fn $fn_name(&self, id: $db_key_type) -> Result<$db_item, AppError> {
-            match self
-                .client()
-                .database(CONFIG.profile)
-                .collection::<$db_item>(format!("{}s", stringify!($db_item)).as_str())
-                .find_one(doc! {"_id": id}, None)
-                .await
-            {
-                Ok(Some(id)) => Ok(id),
-                Ok(None) => Err(AppError::NotFound(format!(
-                    "{}: {} ",
-                    stringify!($db_item),
-                    id.to_string()
-                ))),
-                Err(err) => Err(AppError::MongoDriver(err.to_string())),
-            }
-        }
-    };
-}
-
-macro_rules! impl_get_all {
-    (
-        fn_name=$fn_name:ident,
-        db_item=$db_item:ty,
-        db_coll_name=$db_coll_name:literal
-    ) => {
-        pub async fn $fn_name(&self) -> Result<Vec<$db_item>, AppError> {
-            match self
-                .client()
-                .database(CONFIG.profile)
-                .collection::<$db_item>($db_coll_name)
-                .find(None, None)
-                .await
-            {
-                Ok(docs) => Ok(docs
-                    .try_collect::<Vec<$db_item>>()
-                    .await
-                    .map_err(|e| AppError::MongoDriver(e.to_string()))?),
-                Err(err) => Err(AppError::MongoDriver(err.to_string())),
-            }
-        }
-    };
-}
-
-macro_rules! impl_get_filtered {
-    (
-        fn_name=$fn_name:ident,
-        db_item=$db_item:ty,
-        db_coll_name=$db_coll_name:literal,
-        filter_by=$filter_by:literal,
-        filter_type=$filter_type:literal
-    ) => {
-        pub async fn $fn_name(&self, filter: impl Into<Bson>) -> Result<Vec<$db_item>, AppError> {
-            match self
-                .client()
-                .database(CONFIG.profile)
-                .collection::<$db_item>($db_coll_name)
-                .find(doc! {$filter_by: { $filter_type: filter.into()}}, None)
-                .await
-            {
-                Ok(docs) => Ok(docs
-                    .try_collect::<Vec<$db_item>>()
-                    .await
-                    .map_err(|e| AppError::MongoDriver(e.to_string()))?),
-                Err(err) => Err(AppError::MongoDriver(err.to_string())),
-            }
-        }
-    };
-}
-
-macro_rules! impl_update {
-    (
-        fn_name=$fn_name:ident,
-        db_item=$db_item:ty,
-        db_key_type=$db_key_type:ty,
-        db_coll_name=$db_coll_name:literal
-    ) => {
-        pub async fn $fn_name(
-            &self,
-            id: $db_key_type,
-            document: Document,
-        ) -> Result<$db_item, AppError> {
-            match self
-                .client()
-                .database(CONFIG.profile)
-                .collection::<$db_item>($db_coll_name)
-                .find_one_and_update(
-                    doc! {"_id": id},
-                    UpdateModifications::Document(document),
-                    Some(
-                        FindOneAndUpdateOptions::builder()
-                            .upsert(true)
-                            .return_document(ReturnDocument::After)
-                            .build(),
-                    ),
-                )
-                .await
-            {
-                Ok(item) => item.ok_or_else(|| {
-                    // This should never happen, but to avoid unwrapping we return an explicit error
-                    AppError::NotFound(format!("{}: {}", stringify!($db_item), id.to_string()))
-                }),
-                Err(err) => Err(AppError::MongoDriver(err.to_string())),
-            }
-        }
-    };
-}
-
-macro_rules! impl_delete {
-    (
-        fn_name=$fn_name:ident,
-        db_item=$db_item:ty,
-        db_key_type=$db_key_type:ty,
-        db_coll_name=$db_coll_name:literal
-    ) => {
-        pub async fn $fn_name(&self, id: $db_key_type) -> Result<(), AppError> {
-            match self
-                .client()
-                .database(CONFIG.profile)
-                .collection::<$db_item>($db_coll_name)
-                .delete_one(doc! {"_id": id}, None)
-                .await
-            {
-                Ok(_) => Ok(()),
-                Err(err) => Err(AppError::MongoDriver(err.to_string())),
-            }
-        }
-    };
-}
+use super::{CollectionName, Db, FilterType};
 
 impl Db {
-    // =============== CATALOG CRUD ===============
+    pub async fn get<T>(&self, id: impl Serialize) -> Result<T, AppError>
+    where
+        T: CollectionName + DeserializeOwned + Send + Sync + Unpin,
+    {
+        let id = bson::to_bson(&id)?;
+        self.client()
+            .database(CONFIG.profile)
+            .collection::<T>(T::collection_name())
+            .find_one(doc! {"_id": id.clone()}, None)
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("{}: {}", T::collection_name(), id)))
+    }
 
-    impl_get!(
-        fn_name = get_catalog_by_id,
-        db_item = Catalog,
-        db_key_type = &ObjectId
-    );
+    pub async fn get_all<T>(&self) -> Result<Vec<T>, AppError>
+    where
+        T: CollectionName + DeserializeOwned + Send + Sync + Unpin,
+    {
+        Ok(self
+            .client()
+            .database(CONFIG.profile)
+            .collection::<T>(T::collection_name())
+            .find(None, None)
+            .await?
+            .try_collect::<Vec<T>>()
+            .await?)
+    }
 
-    impl_get_all!(
-        fn_name = get_all_catalogs,
-        db_item = DisplayCatalog,
-        db_coll_name = "Catalogs"
-    );
+    pub async fn get_filtered<T>(
+        &self,
+        filter: impl Into<Bson>,
+        filter_type: FilterType,
+        field_to_filter: impl AsRef<str>,
+    ) -> Result<Vec<T>, AppError>
+    where
+        T: CollectionName + DeserializeOwned + Send + Sync + Unpin,
+    {
+        Ok(self
+            .client()
+            .database(CONFIG.profile)
+            .collection::<T>(T::collection_name())
+            .find(
+                doc! {field_to_filter.as_ref(): { filter_type.as_ref(): filter.into()}},
+                None,
+            )
+            .await?
+            .try_collect::<Vec<T>>()
+            .await?)
+    }
 
-    impl_update!(
-        fn_name = find_and_update_catalog,
-        db_item = Catalog,
-        db_key_type = &ObjectId,
-        db_coll_name = "Catalogs"
-    );
+    pub async fn update<T>(&self, id: impl Serialize, document: Document) -> Result<T, AppError>
+    where
+        T: CollectionName + DeserializeOwned + Send + Sync + Unpin,
+    {
+        let id = bson::to_bson(&id)?;
+        self.client()
+            .database(CONFIG.profile)
+            .collection::<T>(T::collection_name())
+            .find_one_and_update(
+                doc! {"_id": id.clone()},
+                UpdateModifications::Document(document),
+                Some(
+                    FindOneAndUpdateOptions::builder()
+                        .upsert(true)
+                        .return_document(ReturnDocument::After)
+                        .build(),
+                ),
+            )
+            .await?
+            .ok_or_else(|| {
+                // This should never happen, but to avoid unwrapping we return an explicit error
+                AppError::NotFound(format!("{}: {}", T::collection_name(), id))
+            })
+    }
 
-    // =============== COURSE CRUD ===============
-
-    impl_get!(
-        fn_name = get_course_by_id,
-        db_item = Course,
-        db_key_type = &str
-    );
-
-    impl_get_all!(
-        fn_name = get_all_courses,
-        db_item = Course,
-        db_coll_name = "Courses"
-    );
-
-    impl_get_filtered!(
-        fn_name = get_courses_by_ids,
-        db_item = Course,
-        db_coll_name = "Courses",
-        filter_by = "_id",
-        filter_type = "$in"
-    );
-
-    impl_get_filtered!(
-        fn_name = get_courses_filtered_by_name,
-        db_item = Course,
-        db_coll_name = "Courses",
-        filter_by = "name",
-        filter_type = "$regex"
-    );
-
-    impl_get_filtered!(
-        fn_name = get_courses_filtered_by_number,
-        db_item = Course,
-        db_coll_name = "Courses",
-        filter_by = "_id",
-        filter_type = "$regex"
-    );
-
-    impl_update!(
-        fn_name = find_and_update_course,
-        db_item = Course,
-        db_key_type = &str,
-        db_coll_name = "Courses"
-    );
-
-    impl_delete!(
-        fn_name = delete_course,
-        db_item = Course,
-        db_key_type = &str,
-        db_coll_name = "Courses"
-    );
-
-    impl_get_all!(
-        fn_name = get_all_malags,
-        db_item = Malags,
-        db_coll_name = "Malags"
-    );
-
-    // =============== USER CRUD ===============
-
-    impl_get!(fn_name = get_user_by_id, db_item = User, db_key_type = &str);
-
-    impl_update!(
-        fn_name = find_and_update_user,
-        db_item = User,
-        db_key_type = &str,
-        db_coll_name = "Users"
-    );
-
-    // =============== ADMIN CRUD ===============
-
-    impl_get!(
-        fn_name = get_admin_by_id,
-        db_item = Admin,
-        db_key_type = &str
-    );
+    pub async fn delete<T>(&self, id: impl Serialize) -> Result<(), AppError>
+    where
+        T: CollectionName + DeserializeOwned + Send + Sync + Unpin,
+    {
+        let id = bson::to_bson(&id)?;
+        Ok(self
+            .client()
+            .database(CONFIG.profile)
+            .collection::<T>(T::collection_name())
+            .delete_one(doc! {"_id": id.clone()}, None)
+            .await
+            .map(|_| ())?) // Discard the result of the delete operation
+    }
 }

--- a/packages/server/src/error.rs
+++ b/packages/server/src/error.rs
@@ -13,6 +13,24 @@ pub enum AppError {
     MongoDriver(String),    // 500
 }
 
+impl From<mongodb::error::Error> for AppError {
+    fn from(err: mongodb::error::Error) -> Self {
+        AppError::MongoDriver(err.to_string())
+    }
+}
+
+impl From<bson::ser::Error> for AppError {
+    fn from(err: bson::ser::Error) -> Self {
+        AppError::Bson(err.to_string())
+    }
+}
+
+impl From<bson::oid::Error> for AppError {
+    fn from(err: bson::oid::Error) -> Self {
+        AppError::Bson(err.to_string())
+    }
+}
+
 impl ResponseError for AppError {
     fn error_response(&self) -> HttpResponse {
         let (status_code, error) = match self {

--- a/packages/server/src/middleware/from_request.rs
+++ b/packages/server/src/middleware/from_request.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! impl_from_request {
-    (resource=$resource:ty, getter=$get_fn:ident) => {
+    (for $resource:ty) => {
         impl FromRequest for $resource {
             type Error = AppError;
             type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
@@ -18,7 +18,7 @@ macro_rules! impl_from_request {
                     };
                     let optional_sub = req.extensions().get::<Sub>().cloned();
                     match optional_sub {
-                        Some(key) => db.$get_fn(&key).await,
+                        Some(key) => db.get::<$resource>(&key).await,
                         None => Err(AppError::Middleware(
                             "Sub not found in request extensions".into(),
                         )),

--- a/packages/server/src/resources/admin.rs
+++ b/packages/server/src/resources/admin.rs
@@ -1,3 +1,4 @@
+use crate::db::CollectionName;
 use crate::error::AppError;
 use crate::impl_from_request;
 use crate::middleware::auth::Sub;
@@ -17,4 +18,10 @@ pub struct Admin {
     pub faculty: String,
 }
 
-impl_from_request!(resource = Admin, getter = get_admin_by_id);
+impl CollectionName for Admin {
+    fn collection_name() -> &'static str {
+        "Admins"
+    }
+}
+
+impl_from_request!(for Admin);

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -1,5 +1,6 @@
 use crate::{
     core::{credit_transfer_graph::find_traversal_order, types::CreditOverflow},
+    db::CollectionName,
     resources::course::CourseBank,
 };
 use serde::{self, Deserialize, Serialize};
@@ -47,6 +48,11 @@ impl Catalog {
     }
 }
 
+impl CollectionName for Catalog {
+    fn collection_name() -> &'static str {
+        "Catalogs"
+    }
+}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DisplayCatalog {
     #[serde(rename(serialize = "_id", deserialize = "_id"))]
@@ -64,5 +70,11 @@ impl From<Catalog> for DisplayCatalog {
             total_credit: catalog.total_credit,
             description: catalog.description,
         }
+    }
+}
+
+impl CollectionName for DisplayCatalog {
+    fn collection_name() -> &'static str {
+        "Catalogs"
     }
 }

--- a/packages/server/src/resources/course.rs
+++ b/packages/server/src/resources/course.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 
 use crate::core::types::Rule;
+use crate::db::CollectionName;
 
 pub type CourseId = String;
 
@@ -13,6 +14,12 @@ pub struct Course {
     pub id: CourseId,
     pub credit: f32,
     pub name: String,
+}
+
+impl CollectionName for Course {
+    fn collection_name() -> &'static str {
+        "Courses"
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -165,6 +172,12 @@ pub struct Malags {
     #[serde(rename(serialize = "_id", deserialize = "_id"))]
     pub id: bson::oid::ObjectId,
     pub malag_list: Vec<CourseId>,
+}
+
+impl CollectionName for Malags {
+    fn collection_name() -> &'static str {
+        "Malags"
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/server/src/resources/user.rs
+++ b/packages/server/src/resources/user.rs
@@ -1,5 +1,6 @@
 use super::catalog::DisplayCatalog;
 use crate::core::degree_status::DegreeStatus;
+use crate::db::CollectionName;
 use crate::error::AppError;
 use crate::impl_from_request;
 use crate::middleware::auth::Sub;
@@ -31,4 +32,10 @@ pub struct User {
     pub settings: UserSettings,
 }
 
-impl_from_request!(resource = User, getter = get_user_by_id);
+impl CollectionName for User {
+    fn collection_name() -> &'static str {
+        "Users"
+    }
+}
+
+impl_from_request!(for User);


### PR DESCRIPTION
Highlights:  
- Introduce `CollectionName` trait to retrieve the collection name in DB (consider creating a procedural macro for this)
 - impl `From` from many different upstream error types for `AppError` for more ergonomic error handling
 - Remove all of the `impl_get_*!`, `impl_find_*!`, `impl_delete!` etc declarative macros, and instead provide an API of 5 generic functions: `get`, `get_all`, `get_filtered`, `update` and `delete`