### PR TITLE
Include course number in replacement messages

### DIFF
--- a/packages/server/src/core/bank_rule/iterate_courses.rs
+++ b/packages/server/src/core/bank_rule/iterate_courses.rs
@@ -2,32 +2,10 @@ use std::collections::HashMap;
 
 use crate::core::messages;
 use crate::core::types::CreditInfo;
+use crate::resources::catalog::OptionalReplacements;
+use crate::resources::course::{Course, CourseId, CourseStatus};
 
 use super::BankRuleHandler;
-
-#[macro_export]
-macro_rules! check_if_replacement {
-    ($self:ident, $course_status: expr, $course_id_in_list: expr, $replacements: ident, $replacements_msg: ident) => {
-        for course_id in &$self.course_list {
-            if let Some(replacements) =
-                &$self.$replacements.get(course_id)
-            {
-                if replacements.contains(&$course_status.course.id) {
-                    if let Some(course) = $self.courses.get(course_id) {
-                        $course_status
-                            .set_msg(messages::$replacements_msg(&course.name));
-                    } else {
-                        // Shouldn't get here but to prevent crash in case of a bug we use the course id instead
-                        $course_status
-                            .set_msg(messages::$replacements_msg(course_id));
-                    }
-                    $course_id_in_list = Some(course_id);
-                    break;
-                }
-            }
-        }
-    };
-}
 
 impl<'a> BankRuleHandler<'a> {
     pub fn iterate_course_list(&mut self) -> CreditInfo {
@@ -45,25 +23,53 @@ impl<'a> BankRuleHandler<'a> {
                         course_status.course.id.clone(),
                     );
                 } else {
+                    #[inline(always)]
+                    fn check_if_replacement(
+                        course_list: &Vec<CourseId>,
+                        courses: &HashMap<CourseId, Course>,
+                        course_status: &mut CourseStatus,
+                        course_id_in_list: &mut Option<String>,
+                        replacements: &HashMap<CourseId, OptionalReplacements>,
+                        replacements_msg: impl Fn(&Course) -> String,
+                    ) {
+                        for course_id in course_list {
+                            if let Some(replacements) = &replacements.get(course_id) {
+                                if replacements.contains(&course_status.course.id) {
+                                    let optional_course = courses.get(course_id);
+                                    course_status.set_msg(replacements_msg(
+                                        optional_course.unwrap_or(&Course {
+                                            id: course_id.clone(),
+                                            ..Default::default()
+                                        }),
+                                    ));
+
+                                    *course_id_in_list = Some(course_id.into());
+                                    break;
+                                }
+                            }
+                        }
+                    }
                     // check if course_status is a replacement for a course in course list
                     let mut course_id_in_list = None;
                     // First try to find catalog replacements
-                    check_if_replacement!(
-                        self,
+                    check_if_replacement(
+                        &self.course_list,
+                        self.courses,
                         course_status,
-                        course_id_in_list,
-                        catalog_replacements,
-                        catalog_replacements_msg
+                        &mut course_id_in_list,
+                        self.catalog_replacements,
+                        messages::catalog_replacements_msg,
                     );
 
                     if course_id_in_list.is_none() {
                         // Didn't find a catalog replacement so trying to find a common replacement
-                        check_if_replacement!(
-                            self,
+                        check_if_replacement(
+                            &self.course_list,
+                            self.courses,
                             course_status,
-                            course_id_in_list,
-                            common_replacements,
-                            common_replacements_msg
+                            &mut course_id_in_list,
+                            self.common_replacements,
+                            messages::common_replacements_msg,
                         );
                     }
                     if let Some(course_id) = course_id_in_list {

--- a/packages/server/src/core/messages.rs
+++ b/packages/server/src/core/messages.rs
@@ -1,18 +1,21 @@
 use std::fmt::Write;
 
+use crate::resources::course::Course;
+
 const ZERO: f32 = 0.0;
 const HALF: f32 = 0.5;
 const SINGLE: f32 = 1.0;
 
-pub fn common_replacements_msg(name: &str) -> String {
+pub fn common_replacements_msg(course: &Course) -> String {
     format!(
-        "הנחנו כי קורס זה מחליף את הקורס {} בעקבות החלפות נפוצות. שימו לב כי נדרש אישור מהרכזות בשביל החלפה זו",
-        name
+        "הנחנו כי קורס זה מחליף את הקורס {} ({}) בעקבות החלפות נפוצות. שימו לב כי נדרש אישור מהרכזות בשביל החלפה זו",
+        course.name,
+        course.id
     )
 }
 
-pub fn catalog_replacements_msg(name: &str) -> String {
-    format!("קורס זה מחליף את הקורס {}", name)
+pub fn catalog_replacements_msg(course: &Course) -> String {
+    format!("קורס זה מחליף את הקורס {} ({})", course.name, course.id)
 }
 
 pub fn credit_overflow_msg(overflow: f32, from: &str, to: &str) -> String {


### PR DESCRIPTION
This PR also includes a small refactor of the `check_if_replacement!` macro to a (somewhat) generic function.
We should always prefer generics over macros.