### PR TITLE
Fix: remove irrelevant courses on catalog update

### DIFF
--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -61,8 +61,13 @@ pub async fn update_catalog(
 ) -> Result<HttpResponse, AppError> {
     let obj_id = bson::oid::ObjectId::from_str(&catalog_id)?;
     let catalog = db.get::<Catalog>(&obj_id).await?;
-    user.details.catalog = Some(DisplayCatalog::from(catalog));
-    user.details.modified = true;
+
+    // Courses that are not modified, not completed, and don't have a semester should be removed,
+    // since they were not added by the user and they are irrelevant to the new catalog
+    user.details
+        .degree_status
+        .course_statuses
+        .retain(|cs| cs.modified || cs.completed() || cs.semester.is_some());
 
     // Updating the catalog renders the current course statuses invalid in the new catalog's context,
     // so we need to clear them out and let the algorithm recompute them
@@ -75,6 +80,9 @@ pub async fn update_catalog(
             cs.r#type = None;
             cs.modified = false;
         });
+
+    user.details.catalog = Some(DisplayCatalog::from(catalog));
+    user.details.modified = true;
 
     let updated_user = db
         .update::<User>(&user.sub.clone(), doc! {"$set" : to_bson(&user)?})

--- a/packages/sogrim-app/src/stores/DataStore.ts
+++ b/packages/sogrim-app/src/stores/DataStore.ts
@@ -12,7 +12,6 @@ import { RootStore } from "./RootStore";
 export class DataStore {
   public userDetails: UserDetails = {} as UserDetails;
   public userSettings: UserSettings = {} as UserSettings;
-  public userBankNames: string[] = [];
 
   constructor(public readonly rootStore: RootStore) {
     makeAutoObservable(this, { rootStore: false });


### PR DESCRIPTION
Until this change, courses that were added by the degree status algorithm from previous catalogs remained in the course list after switching catalogs, even if they were no longer relevant for the new catalog.