### PR TITLE
Fix course tags update bug

### DIFF
--- a/packages/server/src/db/mod.rs
+++ b/packages/server/src/db/mod.rs
@@ -33,6 +33,7 @@ impl From<Client> for Db {
 pub enum FilterType {
     Regex,
     In,
+    Exists,
 }
 
 impl AsRef<str> for FilterType {
@@ -40,6 +41,7 @@ impl AsRef<str> for FilterType {
         match self {
             FilterType::Regex => "$regex",
             FilterType::In => "$in",
+            FilterType::Exists => "$exists",
         }
     }
 }

--- a/packages/server/src/db/mod.rs
+++ b/packages/server/src/db/mod.rs
@@ -33,7 +33,6 @@ impl From<Client> for Db {
 pub enum FilterType {
     Regex,
     In,
-    Exists,
 }
 
 impl AsRef<str> for FilterType {
@@ -41,7 +40,6 @@ impl AsRef<str> for FilterType {
         match self {
             FilterType::Regex => "$regex",
             FilterType::In => "$in",
-            FilterType::Exists => "$exists",
         }
     }
 }

--- a/packages/server/src/db/services.rs
+++ b/packages/server/src/db/services.rs
@@ -38,9 +38,9 @@ impl Db {
 
     pub async fn get_filtered<T>(
         &self,
-        filter: impl Into<Bson>,
         filter_type: FilterType,
         field_to_filter: impl AsRef<str>,
+        filter: impl Into<Bson>,
     ) -> Result<Vec<T>, AppError>
     where
         T: CollectionName + DeserializeOwned + Send + Sync + Unpin,

--- a/packages/server/src/db/tests.rs
+++ b/packages/server/src/db/tests.rs
@@ -63,7 +63,7 @@ pub async fn test_get_courses_by_filters() {
     let db = Db::new().await;
 
     let courses = db
-        .get_filtered::<Course>("חשבון אינפיניטסימלי 1מ'", FilterType::Regex, "name")
+        .get_filtered::<Course>(FilterType::Regex, "name", "חשבון אינפיניטסימלי 1מ'")
         .await
         .expect("Failed to get courses by name");
 
@@ -72,7 +72,7 @@ pub async fn test_get_courses_by_filters() {
     assert_eq!(courses[0].id, "104031");
 
     let courses = db
-        .get_filtered::<Course>("104031", FilterType::Regex, "_id")
+        .get_filtered::<Course>(FilterType::Regex, "_id", "104031")
         .await
         .expect("Failed to get courses by number");
 
@@ -81,7 +81,7 @@ pub async fn test_get_courses_by_filters() {
     assert_eq!(courses[0].id, "104031");
 
     let courses = db
-        .get_filtered::<Course>(vec!["104031", "104166"], FilterType::In, "_id")
+        .get_filtered::<Course>(FilterType::In, "_id", vec!["104031", "104166"])
         .await
         .expect("Failed to get courses by number");
 


### PR DESCRIPTION
- Update course tags from actually tagged courses rather than updating them from the catalog courses.

This prevented "Malag" and Sport courses' tags from ever being updated, as they don't appear in any catalog.

NOTE: The tests passed because `get_all<Course>` is used, instead of `get_filtered<Course>` like in the actual handler (due to performance considerations). 

We should definitely change this testing behavior, but that is for another issue/PR.