### PR TITLE
fix compute specialization group bank

### DIFF
--- a/packages/server/src/core/degree_status/compute_bank.rs
+++ b/packages/server/src/core/degree_status/compute_bank.rs
@@ -77,15 +77,15 @@ impl<'a> DegreeStatusHandler<'a> {
                 sum_credit = bank_rule_handler
                     .specialization_group(specialization_groups, &mut groups_done_list);
                 completed = groups_done_list.len() >= specialization_groups.groups_number;
-                requirement.message(messages::completed_specialization_groups_msg(
-                    groups_done_list.clone(),
-                    specialization_groups.groups_number,
-                ));
                 if bank.credit.is_none() {
                     requirement
                         .course_requirement(specialization_groups.groups_number)
                         .course_completed(groups_done_list.len());
                 }
+                requirement.message(messages::completed_specialization_groups_msg(
+                    groups_done_list,
+                    specialization_groups.groups_number,
+                ));
             }
             Rule::Wildcard(_) => {
                 sum_credit = 0.0; // TODO: change this

--- a/packages/server/src/core/degree_status/compute_bank.rs
+++ b/packages/server/src/core/degree_status/compute_bank.rs
@@ -1,9 +1,6 @@
+use crate::core::types::Requirement;
 use crate::{
-    core::{
-        bank_rule::BankRuleHandler,
-        messages,
-        types::{Requirement, Rule},
-    },
+    core::{bank_rule::BankRuleHandler, messages, types::Rule},
     resources::course::{CourseBank, CourseId},
 };
 
@@ -31,19 +28,14 @@ impl<'a> DegreeStatusHandler<'a> {
 
         // Initialize necessary variable for rules handling
         let mut sum_credit;
-        let mut count_courses = 0; // for accumulate courses rule
         let mut missing_credit = 0.0; // for all rule
-        let mut groups_done_list = Vec::new(); // for specialization group rule
         let mut completed = true;
-        let mut msg = None;
 
-        // let calculate_new_credit = || -> f32 {
-        //     if let Some(bank_credit) = bank.credit {
-        //         bank_credit - missing_credit + missing_credit_from_prev_banks
-        //     } else {
-        //         0.0
-        //     }
-        // };
+        let mut requirement = Requirement {
+            course_bank_name: bank.name.clone(),
+            bank_rule_name: bank.rule.clone().to_string(),
+            ..Default::default()
+        };
 
         match bank.rule {
             Rule::All => {
@@ -61,8 +53,12 @@ impl<'a> DegreeStatusHandler<'a> {
             }
             Rule::AccumulateCredit => sum_credit = bank_rule_handler.accumulate_credit(),
             Rule::AccumulateCourses(num_courses) => {
+                let mut count_courses = 0;
                 sum_credit = bank_rule_handler.accumulate_courses(&mut count_courses);
                 count_courses = self.handle_courses_overflow(&bank, num_courses, count_courses);
+                requirement
+                    .course_requirement(num_courses)
+                    .course_completed(count_courses);
                 completed = count_courses >= num_courses;
             }
             Rule::Malag => sum_credit = bank_rule_handler.malag(),
@@ -73,57 +69,45 @@ impl<'a> DegreeStatusHandler<'a> {
                 sum_credit = bank_rule_handler.chain(chains, &mut chain_done);
                 completed = !chain_done.is_empty();
                 if completed {
-                    msg = Some(messages::completed_chain_msg(chain_done));
+                    requirement.message(messages::completed_chain_msg(chain_done));
                 }
             }
             Rule::SpecializationGroups(ref specialization_groups) => {
+                let mut groups_done_list = Vec::new();
                 sum_credit = bank_rule_handler
                     .specialization_group(specialization_groups, &mut groups_done_list);
                 completed = groups_done_list.len() >= specialization_groups.groups_number;
-                msg = Some(messages::completed_specialization_groups_msg(
+                requirement.message(messages::completed_specialization_groups_msg(
                     groups_done_list.clone(),
                     specialization_groups.groups_number,
                 ));
+                if bank.credit.is_none() {
+                    requirement
+                        .course_requirement(specialization_groups.groups_number)
+                        .course_completed(groups_done_list.len());
+                }
             }
             Rule::Wildcard(_) => {
                 sum_credit = 0.0; // TODO: change this
             }
         }
 
-        let mut new_bank_credit = None;
-        if let Some(bank_credit) = bank.credit {
-            let new_credit = bank_credit - missing_credit + missing_credit_from_prev_banks;
-            new_bank_credit = Some(new_credit);
-            sum_credit = self.handle_credit_overflow(&bank, new_credit, sum_credit);
-            completed &= sum_credit >= new_credit;
-        } else {
-            sum_credit = self.handle_credit_overflow(&bank, 0.0, sum_credit);
+        match bank.credit {
+            Some(bank_credit) => {
+                let new_bank_credit = bank_credit - missing_credit + missing_credit_from_prev_banks;
+                sum_credit = self.handle_credit_overflow(&bank, new_bank_credit, sum_credit);
+                completed &= sum_credit >= new_bank_credit;
+                requirement.credit_requirement(new_bank_credit);
+            }
+            None => sum_credit = self.handle_credit_overflow(&bank, 0.0, sum_credit),
         };
+
+        requirement
+            .credit_completed(sum_credit)
+            .completed(completed);
 
         self.degree_status
             .course_bank_requirements
-            .push(Requirement {
-                course_bank_name: bank.name.clone(),
-                bank_rule_name: bank.rule.to_string(),
-                credit_requirement: new_bank_credit,
-                course_requirement: match &bank.rule {
-                    Rule::AccumulateCourses(num_courses) => Some(*num_courses),
-                    Rule::SpecializationGroups(sg) if new_bank_credit.is_none() => {
-                        Some(sg.groups_number)
-                    }
-                    _ => None,
-                },
-                credit_completed: sum_credit,
-                course_completed: match &bank.rule {
-                    Rule::AccumulateCourses(_) => count_courses,
-                    Rule::SpecializationGroups(_) if new_bank_credit.is_none() => {
-                        println!("{:#?}", groups_done_list.len());
-                        groups_done_list.len()
-                    }
-                    _ => 0,
-                },
-                completed,
-                message: msg,
-            });
+            .push(requirement);
     }
 }

--- a/packages/server/src/core/types.rs
+++ b/packages/server/src/core/types.rs
@@ -44,16 +44,17 @@ pub enum Rule {
 impl ToString for Rule {
     fn to_string(&self) -> String {
         match self {
-            Rule::All => "all".into(),
-            Rule::AccumulateCredit => "accumulate credit".into(),
-            Rule::AccumulateCourses(_) => "accumulate courses".into(),
-            Rule::Malag => "malag".into(),
-            Rule::Sport => "sport".into(),
-            Rule::Elective => "elective".into(),
-            Rule::Chains(_) => "chains".into(),
-            Rule::SpecializationGroups(_) => "specialization groups".into(),
-            Rule::Wildcard(_) => "wildcard".into(),
+            Rule::All => "all",
+            Rule::AccumulateCredit => "accumulate credit",
+            Rule::AccumulateCourses(_) => "accumulate courses",
+            Rule::Malag => "malag",
+            Rule::Sport => "sport",
+            Rule::Elective => "elective",
+            Rule::Chains(_) => "chains",
+            Rule::SpecializationGroups(_) => "specialization groups",
+            Rule::Wildcard(_) => "wildcard",
         }
+        .into()
     }
 }
 
@@ -78,8 +79,33 @@ pub struct Requirement {
     pub credit_completed: f32,
     pub course_completed: usize,
     pub completed: bool, //Did the user complete the necessary demands for this bank
-    // TODO planing ...
     pub message: Option<String>,
+}
+impl Requirement {
+    pub fn credit_requirement(&mut self, credit: f32) -> &mut Self {
+        self.credit_requirement = Some(credit);
+        self
+    }
+    pub fn course_requirement(&mut self, course: usize) -> &mut Self {
+        self.course_requirement = Some(course);
+        self
+    }
+    pub fn credit_completed(&mut self, credit: f32) -> &mut Self {
+        self.credit_completed = credit;
+        self
+    }
+    pub fn course_completed(&mut self, course: usize) -> &mut Self {
+        self.course_completed = course;
+        self
+    }
+    pub fn completed(&mut self, completed: bool) -> &mut Self {
+        self.completed = completed;
+        self
+    }
+    pub fn message(&mut self, message: String) -> &mut Self {
+        self.message = Some(message);
+        self
+    }
 }
 pub struct CreditInfo {
     pub sum_credit: f32,


### PR DESCRIPTION
We utilize the `course_requirement` mechanism to manage messages for specialized groups. The issue arose because we updated `course_requirement` without updating `course_completed`.
To improve the process of updating `course_completed`, we have implemented the builder design pattern for Requirement.