### PR TITLE
Resolve environment variables at compile time

### DIFF
--- a/packages/server/Cargo.lock
+++ b/packages/server/Cargo.lock
@@ -2702,12 +2702,10 @@ version = "1.3.0"
 dependencies = [
  "actix-cors",
  "actix-rt",
- "actix-service",
  "actix-web",
  "actix-web-lab",
  "bson",
  "colored",
- "derive_more",
  "dotenvy",
  "env_logger",
  "futures-util",
@@ -2721,7 +2719,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
 ]
 
 [[package]]
@@ -2955,15 +2952,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -17,17 +17,16 @@ actix-rt = "2.2"
 actix-web = "4.3"
 actix-web-lab = "0.9"
 actix-cors = "0.6"
-actix-service = "2.0"
 futures-util = "0.3"
 jsonwebtoken = "8.0"
 jsonwebtoken-google = "0.1"
 env_logger = "0.9"
-toml = "0.5"
-dotenvy = "0.15"
 lazy_static = "1.4"
 petgraph = "0.6"
-derive_more = "0.99"
 regex = "1.7.1"
+
+[build-dependencies]
+dotenvy = "0.15"
 
 [dev-dependencies.jsonwebtoken-google]
 version = "0.1" 

--- a/packages/server/build.rs
+++ b/packages/server/build.rs
@@ -1,13 +1,17 @@
 use dotenvy::{dotenv, dotenv_iter};
 
 fn main() {
-    let Ok(dotenv_path) = dotenv() else {
-        // This is not an error, it just means we are in a production environment.
+    let (Ok(dotenv_path), Ok(mut dotenv_iter)) = (dotenv(), dotenv_iter()) else {
+        // In this case, we don't have a .env file and we should assume that the environment variables are already set
+        // NOTE: This is NOT an error, it just means we are in a production or CI environment
         return;
     };
+
+    // rerun-if-changed is used to tell cargo to re-run this build script if the .env file changes
     println!("cargo:rerun-if-changed={}", dotenv_path.display());
-    let mut env_var_iter = dotenv_iter().expect("failed to read .env file");
-    while let Some(Ok((key, value))) = env_var_iter.next() {
+
+    // Set the environment variables
+    while let Some(Ok((key, value))) = dotenv_iter.next() {
         println!("cargo:rustc-env={}={}", key, value);
     }
 }

--- a/packages/server/build.rs
+++ b/packages/server/build.rs
@@ -1,0 +1,13 @@
+use dotenvy::{dotenv, dotenv_iter};
+
+fn main() {
+    let Ok(dotenv_path) = dotenv() else {
+        // This is not an error, it just means we are in a production environment.
+        return;
+    };
+    println!("cargo:rerun-if-changed={}", dotenv_path.display());
+    let mut env_var_iter = dotenv_iter().expect("failed to read .env file");
+    while let Some(Ok((key, value))) = env_var_iter.next() {
+        println!("cargo:rustc-env={}={}", key, value);
+    }
+}

--- a/packages/server/src/api/tests.rs
+++ b/packages/server/src/api/tests.rs
@@ -23,7 +23,6 @@ use actix_web::{
 };
 use actix_web_lab::middleware::from_fn;
 use bson::oid::ObjectId;
-use dotenvy::dotenv;
 
 use super::admins::{self, ComputeDegreeStatusPayload};
 
@@ -32,7 +31,6 @@ pub async fn test_get_all_catalogs() {
     // Create authorization header
     let token_claims = jsonwebtoken_google::test_helper::TokenClaims::new();
     let (jwt, parser, _server) = jsonwebtoken_google::test_helper::setup(&token_claims);
-    dotenv().ok();
     let db = Db::new().await;
     let app = test::init_service(
         App::new()
@@ -60,7 +58,6 @@ pub async fn test_get_all_catalogs() {
 
 #[test]
 async fn test_students_api_full_flow() {
-    dotenv().ok();
     // Create authorization header
 
     let token_claims = jsonwebtoken_google::test_helper::TokenClaims::new();
@@ -151,8 +148,6 @@ async fn test_students_api_full_flow() {
 }
 #[test]
 async fn test_compute_in_progress() {
-    dotenv().ok();
-
     // Init env and app
     let db = Db::new().await;
     let app = test::init_service(
@@ -216,7 +211,6 @@ async fn test_compute_in_progress() {
 
 #[test]
 async fn test_owner_api_courses() {
-    dotenv().ok();
     // Create authorization header
     let token_claims = jsonwebtoken_google::test_helper::TokenClaims::new();
     let (jwt, parser, _server) = jsonwebtoken_google::test_helper::setup(&token_claims);
@@ -290,7 +284,6 @@ async fn test_owner_api_courses() {
 
 #[test]
 async fn test_owner_api_catalogs() {
-    dotenv().ok();
     // Create authorization header
     let token_claims = jsonwebtoken_google::test_helper::TokenClaims::new();
     let (jwt, parser, _server) = jsonwebtoken_google::test_helper::setup(&token_claims);
@@ -321,7 +314,6 @@ async fn test_owner_api_catalogs() {
 
 #[test]
 async fn test_student_login_no_sub() {
-    dotenv().ok();
     // Init env and app
     let db = Db::new().await;
     let app = test::init_service(
@@ -347,7 +339,6 @@ async fn test_student_login_no_sub() {
 #[test]
 async fn test_students_api_no_catalog() {
     // *** IMPORTANT: This should NEVER happen, but the tests are added anyway for coverage
-    dotenv().ok();
     // Init env and app
     let db = Db::new().await;
     let app = test::init_service(
@@ -375,7 +366,6 @@ async fn test_students_api_no_catalog() {
 
 #[test]
 async fn test_admins_parse_and_compute_api() {
-    dotenv().ok();
     // Create authorization header
     let token_claims = jsonwebtoken_google::test_helper::TokenClaims::new();
     let (jwt, parser, _server) = jsonwebtoken_google::test_helper::setup(&token_claims);
@@ -414,7 +404,6 @@ async fn test_admins_parse_and_compute_api() {
 
 #[test]
 async fn test_unauthorized_path() {
-    dotenv().ok();
     // Init env and app
     let db = Db::new().await;
     let app = test::init_service(

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -2,7 +2,7 @@ const IP: &str = env!("IP");
 const PORT: &str = env!("PORT");
 const URI: &str = env!("URI");
 const CLIENT_ID: &str = env!("CLIENT_ID");
-const PROFILE: &str = env!("PROFILE");
+const PROFILE: Option<&str> = option_env!("PROFILE");
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -18,5 +18,11 @@ pub const CONFIG: Config = Config {
     port: PORT,
     uri: URI,
     client_id: CLIENT_ID,
-    profile: PROFILE,
+    profile: 
+    // TODO: use unwrap_or once it's stable in const fn
+    if let Some(profile) = PROFILE {
+        profile
+    } else {
+        "debug"
+    },
 };

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -1,31 +1,22 @@
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref IP: String = std::env::var("IP").expect("Environment Error");
-    static ref PORT: String = std::env::var("PORT").expect("Environment Error");
-    static ref URI: String = std::env::var("URI").expect("Environment Error");
-    static ref CLIENT_ID: String = std::env::var("CLIENT_ID").expect("Environment Error");
-    static ref PROFILE: String = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
-    pub static ref CONFIG: Config<'static> = Config::from_env();
-}
+const IP: &str = env!("IP");
+const PORT: &str = env!("PORT");
+const URI: &str = env!("URI");
+const CLIENT_ID: &str = env!("CLIENT_ID");
+const PROFILE: &str = env!("PROFILE");
 
 #[derive(Debug, Clone)]
-pub struct Config<'cfg> {
-    pub ip: &'cfg str,
-    pub port: u16,
-    pub uri: &'cfg str,
-    pub client_id: &'cfg str,
-    pub profile: &'cfg str,
+pub struct Config {
+    pub ip: &'static str,
+    pub port: &'static str,
+    pub uri: &'static str,
+    pub client_id: &'static str,
+    pub profile: &'static str,
 }
 
-impl Config<'_> {
-    pub fn from_env() -> Self {
-        Config {
-            ip: &IP,
-            port: PORT.parse::<u16>().expect("Failed to parse port"),
-            uri: &URI,
-            client_id: &CLIENT_ID,
-            profile: &PROFILE,
-        }
-    }
-}
+pub const CONFIG: Config = Config {
+    ip: IP,
+    port: PORT,
+    uri: URI,
+    client_id: CLIENT_ID,
+    profile: PROFILE,
+};

--- a/packages/server/src/core/tests.rs
+++ b/packages/server/src/core/tests.rs
@@ -10,7 +10,6 @@ use crate::resources::course::CourseState::NotComplete;
 use crate::resources::course::Grade::Numeric;
 use crate::resources::course::{self, Course, CourseState, CourseStatus, Grade, Tag};
 use actix_rt::test;
-use dotenvy::dotenv;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -24,7 +23,6 @@ pub const MEDICINE_18_19_CATALOG_ID: &str = "63efa36f9e57dc03df270751"; // catal
 
 #[test]
 async fn test_year_catalog() {
-    dotenv().ok();
     let db = Db::new().await;
     let catalog = db
         .get::<Catalog>(
@@ -535,7 +533,6 @@ async fn test_duplicated_courses() {
 // ------------------------------------------------------------------------------------------------------
 
 async fn get_catalog(catalog: &str) -> Catalog {
-    dotenv().ok();
     let db = Db::new().await;
     let obj_id = bson::oid::ObjectId::from_str(catalog).expect("failed to create oid");
     db.get::<Catalog>(&obj_id)
@@ -544,7 +541,6 @@ async fn get_catalog(catalog: &str) -> Catalog {
 }
 
 async fn run_degree_status(mut degree_status: DegreeStatus, catalog: Catalog) -> DegreeStatus {
-    dotenv().ok();
     let db = Db::new().await;
     let vec_courses = db
         .get_all::<Course>()

--- a/packages/server/src/db/tests.rs
+++ b/packages/server/src/db/tests.rs
@@ -6,7 +6,6 @@ use crate::{
 use actix_rt::test;
 use actix_web::{body::MessageBody, http::StatusCode, ResponseError};
 
-use dotenvy::dotenv;
 use mongodb::{
     options::{ClientOptions, Credential},
     Client,
@@ -14,7 +13,6 @@ use mongodb::{
 
 #[test]
 pub async fn test_db_internal_error() {
-    dotenv().ok();
     // Create explicit client options and update it manually
     let mut client_options = ClientOptions::parse(CONFIG.uri)
         .await
@@ -65,8 +63,6 @@ pub async fn test_db_internal_error() {
 
 #[test]
 pub async fn test_get_courses_by_filters() {
-    dotenv().ok();
-
     let db = Db::new().await;
 
     let courses = db

--- a/packages/server/src/error.rs
+++ b/packages/server/src/error.rs
@@ -1,7 +1,6 @@
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
-use derive_more::Display;
 
-#[derive(Debug, Display)]
+#[derive(Debug)]
 pub enum AppError {
     BadRequest(String),     // 400
     Bson(String),           // 400
@@ -28,6 +27,22 @@ impl From<bson::ser::Error> for AppError {
 impl From<bson::oid::Error> for AppError {
     fn from(err: bson::oid::Error) -> Self {
         AppError::Bson(err.to_string())
+    }
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let error = match self {
+            AppError::BadRequest(e) => e.to_owned(),
+            AppError::Bson(e) => format!("Bson error: {e}"),
+            AppError::Parser(e) => format!("Parser error: {e}"),
+            AppError::Unauthorized(e) => format!("Permission denied: {e}"),
+            AppError::NotFound(e) => format!("{e} not found"),
+            AppError::InternalServer(e) => e.to_owned(),
+            AppError::Middleware(e) => format!("Middleware error: {e}"),
+            AppError::MongoDriver(e) => format!("MongoDB driver error: {e}"),
+        };
+        write!(f, "{}", error)
     }
 }
 

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -5,7 +5,6 @@ use actix_web::{
 };
 use actix_web_lab::middleware::from_fn;
 use db::Db;
-use dotenvy::dotenv;
 use error::AppError;
 use middleware::{auth, cors, logger};
 use resources::user::Permissions;
@@ -21,9 +20,6 @@ mod resources;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Load .env (in development environment)
-    dotenv().ok();
-
     // Initialize logger
     logger::init_env_logger();
 
@@ -75,7 +71,7 @@ async fn main() -> std::io::Result<()> {
                     ),
             )
     })
-    .bind((CONFIG.ip, CONFIG.port))?
+    .bind(format!("{}:{}", CONFIG.ip, CONFIG.port))?
     .run()
     .await
 }

--- a/packages/server/src/middleware/tests.rs
+++ b/packages/server/src/middleware/tests.rs
@@ -11,15 +11,12 @@ use actix_web::{
     App,
 };
 use actix_web_lab::middleware::from_fn;
-use dotenvy::dotenv;
 
 #[test]
 async fn test_from_request_no_db_client() {
     // Create authorization header
     let token_claims = jsonwebtoken_google::test_helper::TokenClaims::new();
     let (jwt, parser, _server) = jsonwebtoken_google::test_helper::setup(&token_claims);
-    //Init env and app
-    dotenv().ok();
     let app = test::init_service(
         App::new()
             .app_data(middleware::auth::JwtDecoder::new_with_parser(parser))
@@ -47,8 +44,6 @@ async fn test_from_request_no_db_client() {
 
 #[test]
 async fn test_from_request_no_auth_mw() {
-    //Init env and app
-    dotenv().ok();
     let db = Db::new().await;
     let app = test::init_service(
         App::new()
@@ -77,8 +72,6 @@ async fn test_from_request_no_auth_mw() {
 
 #[test]
 async fn test_auth_mw_no_jwt_decoder() {
-    //Init env and app
-    dotenv().ok();
     let db = Db::new().await;
     let app = test::init_service(
         App::new()
@@ -111,8 +104,6 @@ async fn test_auth_mw_no_jwt_decoder() {
 async fn test_auth_mw_client_errors() {
     let token_claims = jsonwebtoken_google::test_helper::TokenClaims::new_expired();
     let (expired_jwt, parser, _server) = jsonwebtoken_google::test_helper::setup(&token_claims);
-    //Init env and app
-    dotenv().ok();
     let app = test::init_service(
         App::new()
             .app_data(middleware::auth::JwtDecoder::new_with_parser(parser))


### PR DESCRIPTION
This PR's main purpose is to utilize the `env!` macro to resolve environment variables at compile time. 
This means that if a required env var is missing, the build will _fail to compile_, as opposed to what we had so far, which was only a run-time check, resulting in a _run-time error_ instead.
As a bonus, by using a `build.rs` script (which allows us to modify how `cargo` builds the project) we can also get rid of all the annoying `dotenv().ok()` everywhere in the codebase

- Also removed some unused dependencies