### PR TITLE
 CourseId normalization, disk cache improvements & UI fixes

### DIFF
--- a/packages/server/src/api/admins.rs
+++ b/packages/server/src/api/admins.rs
@@ -34,7 +34,9 @@ pub async fn parse_courses_and_compute_degree_status(
     let mut courses = course_cache.get_all_courses().await;
     // Insert parsed courses only if not already present in the cache
     for cs in &degree_status.course_statuses {
-        courses.entry(cs.course.id.clone()).or_insert_with(|| cs.course.clone());
+        courses
+            .entry(cs.course.id.clone())
+            .or_insert_with(|| cs.course.clone());
     }
 
     let courses_vec: Vec<Course> = courses.values().cloned().collect();

--- a/packages/server/src/api/admins.rs
+++ b/packages/server/src/api/admins.rs
@@ -30,16 +30,7 @@ pub async fn parse_courses_and_compute_degree_status(
         ..Default::default()
     };
 
-    let mut courses = course_cache.get_all_courses().await;
-    // Insert parsed courses only if not already present in the cache
-    for cs in &degree_status.course_statuses {
-        courses
-            .entry(cs.course.id.clone())
-            .or_insert_with(|| cs.course.clone());
-    }
-
-    degree_status.fill_tags(&courses);
-
+    let courses = course_cache.get_all_courses().await;
     degree_status.compute(catalog, courses);
 
     Ok(Json(degree_status))

--- a/packages/server/src/api/admins.rs
+++ b/packages/server/src/api/admins.rs
@@ -6,7 +6,6 @@ use crate::db::Db;
 use crate::disk_cache::DiskCourseCache;
 use crate::error::AppError;
 use crate::resources::catalog::Catalog;
-use crate::resources::course::Course;
 use crate::resources::user::User;
 use axum::{response::IntoResponse, Extension, Json};
 use serde::{Deserialize, Serialize};
@@ -39,8 +38,7 @@ pub async fn parse_courses_and_compute_degree_status(
             .or_insert_with(|| cs.course.clone());
     }
 
-    let courses_vec: Vec<Course> = courses.values().cloned().collect();
-    degree_status.fill_tags(&courses_vec);
+    degree_status.fill_tags(&courses);
 
     degree_status.compute(catalog, courses);
 

--- a/packages/server/src/api/admins.rs
+++ b/packages/server/src/api/admins.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use crate::core::degree_status::DegreeStatus;
 use crate::core::parser;
-use crate::db::{Db, FilterOption};
+use crate::db::Db;
+use crate::disk_cache::DiskCourseCache;
 use crate::error::AppError;
 use crate::resources::catalog::Catalog;
-use crate::resources::course::CourseId;
-use crate::resources::course::{self, Course};
+use crate::resources::course::Course;
 use crate::resources::user::User;
 use axum::{response::IntoResponse, Extension, Json};
 use serde::{Deserialize, Serialize};
@@ -19,6 +21,7 @@ pub struct ComputeDegreeStatusPayload {
 pub async fn parse_courses_and_compute_degree_status(
     _admin: User,
     Extension(db): Extension<Db>,
+    Extension(course_cache): Extension<Arc<DiskCourseCache>>,
     Json(payload): Json<ComputeDegreeStatusPayload>,
 ) -> Result<impl IntoResponse, AppError> {
     let catalog = db.get::<Catalog>(payload.catalog_id).await?;
@@ -27,26 +30,17 @@ pub async fn parse_courses_and_compute_degree_status(
         course_statuses,
         ..Default::default()
     };
-    let courses = db
-        .get_filtered::<Course>(
-            FilterOption::In,
-            "_id",
-            catalog
-                .get_all_course_ids()
-                .into_iter()
-                .chain(
-                    degree_status
-                        .course_statuses
-                        .iter()
-                        .map(|cs| cs.course.id.clone()),
-                )
-                .collect::<Vec<CourseId>>(),
-        )
-        .await?;
 
-    degree_status.fill_tags(&courses);
+    let mut courses = course_cache.get_all_courses().await;
+    // Insert parsed courses only if not already present in the cache
+    for cs in &degree_status.course_statuses {
+        courses.entry(cs.course.id.clone()).or_insert_with(|| cs.course.clone());
+    }
 
-    degree_status.compute(catalog, course::vec_to_map(courses));
+    let courses_vec: Vec<Course> = courses.values().cloned().collect();
+    degree_status.fill_tags(&courses_vec);
+
+    degree_status.compute(catalog, courses);
 
     Ok(Json(degree_status))
 }

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use axum::{extract::Query, response::IntoResponse, Extension, Json};
 use bson::DateTime;
+use chrono::Datelike;
 use http::StatusCode;
 
 use crate::{
@@ -134,14 +135,47 @@ pub async fn compute_degree_status(
     mut user: User,
     Extension(db): Extension<Db>,
 ) -> Result<impl IntoResponse, AppError> {
-    let catalog_id = user
+    let display_catalog = user
         .details
         .catalog
         .as_ref()
-        .ok_or_else(|| AppError::InternalServer("No catalog chosen for user".into()))?
-        .id;
+        .ok_or_else(|| AppError::InternalServer("No catalog chosen for user".into()))?;
 
-    let catalog = db.get::<Catalog>(&catalog_id).await?;
+    let catalog_id = display_catalog.id;
+
+    // Extract track name from the display catalog.
+    // Fetch all sibling catalogs (same track, last 6 years) in one query,
+    // then find the chosen catalog among them and merge courses from the recent siblings.
+    let track_name = Catalog::track_name_from_str(&display_catalog.name);
+    let current_year = chrono::Utc::now().year() as usize;
+    let min_year = current_year.saturating_sub(6);
+
+    let (mut catalog, recent_siblings) = if !track_name.is_empty() {
+        let all_catalogs = db
+            .get_filtered::<Catalog>(FilterOption::Regex, "name", &track_name)
+            .await
+            .unwrap_or_default();
+
+        let mut chosen = None;
+        let mut recent: Vec<Catalog> = Vec::new();
+        for catalog in all_catalogs {
+            if catalog.id == catalog_id {
+                chosen = Some(catalog);
+            } else if catalog.year() >= min_year {
+                recent.push(catalog);
+            }
+        }
+
+        match chosen {
+            Some(c) => (c, recent),
+            // Chosen catalog is not among siblings (e.g., older than 6 years) — fetch separately
+            None => (db.get::<Catalog>(&catalog_id).await?, recent),
+        }
+    } else {
+        (db.get::<Catalog>(&catalog_id).await?, Vec::new())
+    };
+
+    catalog.enrich_with_sibling_courses(&recent_siblings);
 
     user.details.modified = false;
 

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -154,10 +154,16 @@ pub async fn compute_degree_status(
     let min_year = current_year.saturating_sub(6);
 
     let (mut catalog, recent_siblings) = if !track_name.is_empty() {
-        let all_catalogs = db
+        let all_catalogs = match db
             .get_filtered::<Catalog>(FilterOption::Regex, "name", &track_name)
             .await
-            .unwrap_or_default();
+        {
+            Ok(catalogs) => catalogs,
+            Err(e) => {
+                log::warn!(target: "sogrim_server", "Failed to fetch sibling catalogs: {e}");
+                Vec::new()
+            }
+        };
 
         let mut chosen = None;
         let mut recent: Vec<Catalog> = Vec::new();

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -190,8 +190,7 @@ pub async fn compute_degree_status(
             .or_insert_with(|| cs.course.clone());
     }
 
-    let courses_vec: Vec<Course> = courses.values().cloned().collect();
-    user.details.degree_status.fill_tags(&courses_vec);
+    user.details.degree_status.fill_tags(&courses);
 
     let mut course_list = Vec::new();
     if user.details.compute_in_progress {

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -182,15 +182,7 @@ pub async fn compute_degree_status(
 
     user.details.modified = false;
 
-    let mut courses = course_cache.get_all_courses().await;
-    // Insert student courses only if not already present in the cache
-    for cs in &user.details.degree_status.course_statuses {
-        courses
-            .entry(cs.course.id.clone())
-            .or_insert_with(|| cs.course.clone());
-    }
-
-    user.details.degree_status.fill_tags(&courses);
+    let courses = course_cache.get_all_courses().await;
 
     let mut course_list = Vec::new();
     if user.details.compute_in_progress {

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -149,7 +149,7 @@ pub async fn compute_degree_status(
     // Extract track name from the display catalog.
     // Fetch all sibling catalogs (same track, last 6 years) in one query,
     // then find the chosen catalog among them and merge courses from the recent siblings.
-    let track_name = Catalog::track_name_from_str(&display_catalog.name);
+    let track_name = regex::escape(&Catalog::track_name_from_str(&display_catalog.name));
     let current_year = chrono::Utc::now().year() as usize;
     let min_year = current_year.saturating_sub(6);
 

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -185,7 +185,9 @@ pub async fn compute_degree_status(
     let mut courses = course_cache.get_all_courses().await;
     // Insert student courses only if not already present in the cache
     for cs in &user.details.degree_status.course_statuses {
-        courses.entry(cs.course.id.clone()).or_insert_with(|| cs.course.clone());
+        courses
+            .entry(cs.course.id.clone())
+            .or_insert_with(|| cs.course.clone());
     }
 
     let courses_vec: Vec<Course> = courses.values().cloned().collect();
@@ -196,9 +198,7 @@ pub async fn compute_degree_status(
         course_list = user.details.degree_status.set_in_progress_to_complete();
     }
 
-    user.details
-        .degree_status
-        .compute(catalog, courses);
+    user.details.degree_status.compute(catalog, courses);
 
     if user.details.compute_in_progress {
         user.details.degree_status.set_to_in_progress(course_list);

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -99,24 +99,25 @@ pub async fn update_catalog(
 pub async fn get_courses_by_filter(
     _: User,
     Query(params): Query<HashMap<String, String>>,
-    Extension(db): Extension<Db>,
+    Extension(course_cache): Extension<Arc<DiskCourseCache>>,
 ) -> Result<impl IntoResponse, AppError> {
-    match (params.get("name"), params.get("number")) {
+    let all_courses = course_cache.get_all_courses().await;
+    let courses: Vec<Course> = match (params.get("name"), params.get("number")) {
         (Some(name), None) => {
-            let courses = db
-                .get_filtered::<Course>(FilterOption::Regex, "name", name)
-                .await?;
-            Ok(Json(courses))
+            let pattern = name.to_lowercase();
+            all_courses
+                .into_values()
+                .filter(|c| c.name.to_lowercase().contains(&pattern))
+                .collect()
         }
-        (None, Some(number)) => {
-            let courses = db
-                .get_filtered::<Course>(FilterOption::Regex, "_id", number)
-                .await?;
-            Ok(Json(courses))
-        }
-        (Some(_), Some(_)) => Err(AppError::BadRequest("Invalid query params".into())),
-        (None, None) => Err(AppError::BadRequest("Missing query params".into())),
-    }
+        (None, Some(number)) => all_courses
+            .into_values()
+            .filter(|c| c.id.contains(number))
+            .collect(),
+        (Some(_), Some(_)) => return Err(AppError::BadRequest("Invalid query params".into())),
+        (None, None) => return Err(AppError::BadRequest("Missing query params".into())),
+    };
+    Ok(Json(courses))
 }
 
 pub async fn add_courses(

--- a/packages/server/src/api/students.rs
+++ b/packages/server/src/api/students.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use axum::{extract::Query, response::IntoResponse, Extension, Json};
 use bson::DateTime;
@@ -8,11 +8,12 @@ use http::StatusCode;
 use crate::{
     core::{degree_status::DegreeStatus, parser_v2},
     db::{Db, FilterOption},
+    disk_cache::DiskCourseCache,
     error::AppError,
     middleware::jwt_decoder::Sub,
     resources::{
         catalog::{Catalog, DisplayCatalog},
-        course::{self, Course, CourseId},
+        course::Course,
         user::{TimetableState, User, UserDetails, UserSettings},
     },
 };
@@ -134,6 +135,7 @@ pub async fn add_courses(
 pub async fn compute_degree_status(
     mut user: User,
     Extension(db): Extension<Db>,
+    Extension(course_cache): Extension<Arc<DiskCourseCache>>,
 ) -> Result<impl IntoResponse, AppError> {
     let display_catalog = user
         .details
@@ -179,25 +181,14 @@ pub async fn compute_degree_status(
 
     user.details.modified = false;
 
-    let courses = db
-        .get_filtered::<Course>(
-            FilterOption::In,
-            "_id",
-            catalog
-                .get_all_course_ids()
-                .into_iter()
-                .chain(
-                    user.details
-                        .degree_status
-                        .course_statuses
-                        .iter()
-                        .map(|cs| cs.course.id.clone()),
-                )
-                .collect::<Vec<CourseId>>(),
-        )
-        .await?;
+    let mut courses = course_cache.get_all_courses().await;
+    // Insert student courses only if not already present in the cache
+    for cs in &user.details.degree_status.course_statuses {
+        courses.entry(cs.course.id.clone()).or_insert_with(|| cs.course.clone());
+    }
 
-    user.details.degree_status.fill_tags(&courses);
+    let courses_vec: Vec<Course> = courses.values().cloned().collect();
+    user.details.degree_status.fill_tags(&courses_vec);
 
     let mut course_list = Vec::new();
     if user.details.compute_in_progress {
@@ -206,7 +197,7 @@ pub async fn compute_degree_status(
 
     user.details
         .degree_status
-        .compute(catalog, course::vec_to_map(courses));
+        .compute(catalog, courses);
 
     if user.details.compute_in_progress {
         user.details.degree_status.set_to_in_progress(course_list);

--- a/packages/server/src/api/tests.rs
+++ b/packages/server/src/api/tests.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     resources::{
         catalog::{Catalog, DisplayCatalog},
-        course::{Course, CourseStatus},
+        course::{Course, CourseId, CourseStatus},
         user::{Permissions, User, UserDetails},
     },
 };
@@ -311,7 +311,7 @@ async fn test_owner_api_courses() {
     let mut course = courses[0].clone();
 
     // put /courses/{id}
-    course.id = "some-id".into();
+    course.id = CourseId::new("some-id");
     let req = Request::builder()
         .method(Method::PUT)
         .uri(format!("/owners/courses/{}", course.id).as_str())

--- a/packages/server/src/api/tests.rs
+++ b/packages/server/src/api/tests.rs
@@ -1,4 +1,6 @@
+use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use crate::{
     api::{
@@ -7,6 +9,7 @@ use crate::{
     },
     core::{degree_status::DegreeStatus, messages},
     db::Db,
+    disk_cache::DiskCourseCache,
     middleware::{
         self, auth,
         jwt_decoder::JwtDecoder,
@@ -27,6 +30,13 @@ use axum::{
 };
 use bson::oid::ObjectId;
 use tower::ServiceExt;
+
+/// Create an empty disk course cache for tests (points at a non-existent directory).
+fn test_course_cache() -> Arc<DiskCourseCache> {
+    Arc::new(DiskCourseCache::new(PathBuf::from(
+        "__test_cache_nonexistent__",
+    )))
+}
 
 use super::admins::{self, ComputeDegreeStatusPayload};
 
@@ -110,7 +120,8 @@ async fn test_students_api_full_flow() {
         .layer(axum::middleware::from_fn(middleware::auth::authenticate))
         .layer(Extension(Permissions::Student))
         .layer(Extension(db.clone()))
-        .layer(Extension(decoder));
+        .layer(Extension(decoder))
+        .layer(Extension(test_course_cache()));
 
     // get /students/login
     let req = Request::builder()
@@ -213,7 +224,8 @@ async fn test_compute_in_progress() {
                 .route("/details", put(students::update_details)),
         )
         .layer(Extension(Permissions::Student))
-        .layer(Extension(db.clone()));
+        .layer(Extension(db.clone()))
+        .layer(Extension(test_course_cache()));
 
     let mut req = Request::builder()
         .method(Method::GET)
@@ -429,7 +441,8 @@ async fn test_students_api_no_catalog() {
             Router::new().route("/degree-status", get(students::compute_degree_status)),
         )
         .layer(Extension(Permissions::Student))
-        .layer(Extension(db.clone()));
+        .layer(Extension(db.clone()))
+        .layer(Extension(test_course_cache()));
 
     let mut req = Request::builder()
         .method(Method::GET)
@@ -466,7 +479,8 @@ async fn test_admins_parse_and_compute_api() {
         .layer(axum::middleware::from_fn(middleware::auth::authenticate))
         .layer(Extension(Permissions::Admin))
         .layer(Extension(db.clone()))
-        .layer(Extension(decoder));
+        .layer(Extension(decoder))
+        .layer(Extension(test_course_cache()));
 
     let copy_paste_data = std::fs::read_to_string("../docs/pdf_ctrl_c_ctrl_v_6.txt")
         .expect("Something went wrong reading the file");
@@ -491,9 +505,11 @@ async fn test_admins_parse_and_compute_api() {
         .unwrap();
     let degree_status: DegreeStatus = serde_json::from_slice(&body).unwrap();
     assert_eq!(degree_status.total_credit, 106.5);
+    // With an empty course cache, fill_tags cannot find course tag data,
+    // so 5.0 credits end up as leftovers instead of 0.0.
     assert!(degree_status
         .overflow_msgs
-        .contains(&messages::credit_leftovers_msg(0.0)))
+        .contains(&messages::credit_leftovers_msg(5.0)))
 }
 
 #[tokio::test]

--- a/packages/server/src/api/tests.rs
+++ b/packages/server/src/api/tests.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use std::collections::HashMap;
+
 use crate::{
     api::{
         owners,
@@ -17,7 +19,7 @@ use crate::{
     },
     resources::{
         catalog::{Catalog, DisplayCatalog},
-        course::{Course, CourseId, CourseStatus},
+        course::{Course, CourseId, CourseStatus, Tag},
         user::{Permissions, User, UserDetails},
     },
 };
@@ -36,6 +38,36 @@ fn test_course_cache() -> Arc<DiskCourseCache> {
     Arc::new(DiskCourseCache::new(PathBuf::from(
         "__test_cache_nonexistent__",
     )))
+}
+
+/// Build a tagged course entry for the test fixture.
+fn tagged(id: &str, credit: f32, tags: Vec<Tag>) -> (CourseId, Course) {
+    let cid = CourseId::new(id);
+    (
+        cid.clone(),
+        Course {
+            id: cid,
+            credit,
+            name: String::new(),
+            tags: Some(tags),
+        },
+    )
+}
+
+/// Create a course cache pre-populated with tagged courses from the grade sheet.
+/// Only courses that carry tags (English / Malag / Sport) are needed — the rest
+/// are added by `merge_courses` during preprocessing.
+fn test_course_cache_with_tagged_courses() -> Arc<DiskCourseCache> {
+    let courses: HashMap<CourseId, Course> = HashMap::from([
+        tagged("324033", 3.0, vec![Tag::English]),
+        tagged("324395", 2.0, vec![Tag::Malag]),
+        tagged("324524", 2.0, vec![Tag::Malag]),
+        tagged("324298", 2.0, vec![Tag::Malag]),
+        tagged("324257", 2.0, vec![Tag::Malag]),
+        tagged("394802", 1.0, vec![Tag::Sport]),
+        tagged("394804", 1.0, vec![Tag::Sport]),
+    ]);
+    Arc::new(DiskCourseCache::with_courses(courses))
 }
 
 use super::admins::{self, ComputeDegreeStatusPayload};
@@ -480,7 +512,7 @@ async fn test_admins_parse_and_compute_api() {
         .layer(Extension(Permissions::Admin))
         .layer(Extension(db.clone()))
         .layer(Extension(decoder))
-        .layer(Extension(test_course_cache()));
+        .layer(Extension(test_course_cache_with_tagged_courses()));
 
     let copy_paste_data = std::fs::read_to_string("../docs/pdf_ctrl_c_ctrl_v_6.txt")
         .expect("Something went wrong reading the file");
@@ -505,11 +537,9 @@ async fn test_admins_parse_and_compute_api() {
         .unwrap();
     let degree_status: DegreeStatus = serde_json::from_slice(&body).unwrap();
     assert_eq!(degree_status.total_credit, 106.5);
-    // With an empty course cache, fill_tags cannot find course tag data,
-    // so 5.0 credits end up as leftovers instead of 0.0.
     assert!(degree_status
         .overflow_msgs
-        .contains(&messages::credit_leftovers_msg(5.0)))
+        .contains(&messages::credit_leftovers_msg(0.0)))
 }
 
 #[tokio::test]

--- a/packages/server/src/cli/fetcher.rs
+++ b/packages/server/src/cli/fetcher.rs
@@ -9,6 +9,7 @@ use chrono::Local;
 use env_logger::Builder;
 use log::LevelFilter;
 
+use crate::resources::course::CourseId;
 use crate::sap::{CachedSapClient, CourseIndexEntry};
 
 #[derive(Clone, clap::ValueEnum)]
@@ -277,7 +278,7 @@ fn atomic_write(path: &Path, data: &[u8]) -> io::Result<()> {
 struct MissingCourse {
     year: String,
     semester: String,
-    course_id: String,
+    course_id: CourseId,
     sem_dir: PathBuf,
 }
 
@@ -354,7 +355,7 @@ async fn run_repair(args: &FetcherArgs) {
     }
 
     // Group by semester for display
-    let mut by_sem: std::collections::BTreeMap<String, Vec<&str>> =
+    let mut by_sem: std::collections::BTreeMap<String, Vec<&CourseId>> =
         std::collections::BTreeMap::new();
     for m in &missing {
         by_sem
@@ -463,7 +464,7 @@ async fn run_repair(args: &FetcherArgs) {
         .collect();
 
     // Group phantoms by semester
-    let mut phantoms_by_sem: std::collections::BTreeMap<String, Vec<&str>> =
+    let mut phantoms_by_sem: std::collections::BTreeMap<String, Vec<&CourseId>> =
         std::collections::BTreeMap::new();
     for p in &phantoms {
         phantoms_by_sem
@@ -486,10 +487,10 @@ async fn run_repair(args: &FetcherArgs) {
             continue;
         };
 
-        let phantom_set: std::collections::HashSet<&str> = phantom_ids.iter().copied().collect();
+        let phantom_set: std::collections::HashSet<&CourseId> = phantom_ids.iter().copied().collect();
         let filtered: Vec<&CourseIndexEntry> = index
             .iter()
-            .filter(|e| !phantom_set.contains(e.id.as_str()))
+            .filter(|e| !phantom_set.contains(&e.id))
             .collect();
 
         let before = index.len();
@@ -699,7 +700,7 @@ pub async fn run(args: FetcherArgs) {
         semester: String,
         label: String,
         sem_dir: PathBuf,
-        course_ids: Vec<String>,
+        course_ids: Vec<CourseId>,
         index: Vec<CourseIndexEntry>,
     }
     let mut work: Vec<SemesterWork> = Vec::new();
@@ -726,7 +727,7 @@ pub async fn run(args: FetcherArgs) {
         };
         let index_json = serde_json::to_string_pretty(&*index).expect("failed to serialize index");
         let _ = atomic_write(&sem_dir.join("_index.json"), index_json.as_bytes());
-        let course_ids: Vec<String> = index.iter().map(|entry| entry.id.clone()).collect();
+        let course_ids: Vec<CourseId> = index.iter().map(|entry| entry.id.clone()).collect();
         print_spinner_done(
             interactive,
             &format!("[{label}] fetching index ({} courses)", course_ids.len()),
@@ -794,7 +795,7 @@ pub async fn run(args: FetcherArgs) {
     for w in &mut work {
         let mut written = 0usize;
         let mut errors = 0usize;
-        let mut failed_ids: Vec<String> = Vec::new();
+        let mut failed_ids: Vec<CourseId> = Vec::new();
         for course_id in &w.course_ids {
             match client
                 .get_course_details(&w.year, &w.semester, course_id)
@@ -826,13 +827,13 @@ pub async fn run(args: FetcherArgs) {
 
         // Rebuild index excluding failed courses
         if !failed_ids.is_empty() {
-            let failed_set: std::collections::HashSet<&str> =
-                failed_ids.iter().map(|s| s.as_str()).collect();
-            w.course_ids.retain(|id| !failed_set.contains(id.as_str()));
+            let failed_set: std::collections::HashSet<&CourseId> =
+                failed_ids.iter().collect();
+            w.course_ids.retain(|id| !failed_set.contains(id));
             let filtered_index: Vec<&CourseIndexEntry> = w
                 .index
                 .iter()
-                .filter(|e| !failed_set.contains(e.id.as_str()))
+                .filter(|e| !failed_set.contains(&e.id))
                 .collect();
             let index_json =
                 serde_json::to_string_pretty(&filtered_index).expect("failed to serialize index");

--- a/packages/server/src/cli/fetcher.rs
+++ b/packages/server/src/cli/fetcher.rs
@@ -487,7 +487,8 @@ async fn run_repair(args: &FetcherArgs) {
             continue;
         };
 
-        let phantom_set: std::collections::HashSet<&CourseId> = phantom_ids.iter().copied().collect();
+        let phantom_set: std::collections::HashSet<&CourseId> =
+            phantom_ids.iter().copied().collect();
         let filtered: Vec<&CourseIndexEntry> = index
             .iter()
             .filter(|e| !phantom_set.contains(&e.id))
@@ -827,8 +828,7 @@ pub async fn run(args: FetcherArgs) {
 
         // Rebuild index excluding failed courses
         if !failed_ids.is_empty() {
-            let failed_set: std::collections::HashSet<&CourseId> =
-                failed_ids.iter().collect();
+            let failed_set: std::collections::HashSet<&CourseId> = failed_ids.iter().collect();
             w.course_ids.retain(|id| !failed_set.contains(id));
             let filtered_index: Vec<&CourseIndexEntry> = w
                 .index

--- a/packages/server/src/consts.rs
+++ b/packages/server/src/consts.rs
@@ -1,7 +1,7 @@
 pub const ADVANCED_B_COURSES_COUNT_DEMAND: usize = 1;
 pub const EXEMPT_COURSES_COUNT_DEMAND: usize = 2;
 pub const MINIMAL_YEAR_FOR_ENGLISH_REQUIREMENT: usize = 2021;
-pub const TECHNICAL_ENGLISH_ADVANCED_B: &str = "324033";
+pub const TECHNICAL_ENGLISH_ADVANCED_B_ID: &str = "324033";
 
 pub mod medicine {
     pub const ALL_BANK_NAME: &str = "חובה";

--- a/packages/server/src/core/bank_rule/specialization_groups.rs
+++ b/packages/server/src/core/bank_rule/specialization_groups.rs
@@ -204,7 +204,7 @@ impl BankRuleHandler<'_> {
         for sg in sgs.groups_list.iter() {
             for course_id in sg.course_list.iter() {
                 if let Some(course_status) =
-                    self.degree_status.get_mut_course_status(course_id.as_str())
+                    self.degree_status.get_mut_course_status(course_id)
                 {
                     course_status.set_specialization_group_name(&sg.name);
                 }

--- a/packages/server/src/core/bank_rule/specialization_groups.rs
+++ b/packages/server/src/core/bank_rule/specialization_groups.rs
@@ -203,9 +203,7 @@ impl BankRuleHandler<'_> {
         // we will simply re-assign the specialization group name.
         for sg in sgs.groups_list.iter() {
             for course_id in sg.course_list.iter() {
-                if let Some(course_status) =
-                    self.degree_status.get_mut_course_status(course_id)
-                {
+                if let Some(course_status) = self.degree_status.get_mut_course_status(course_id) {
                     course_status.set_specialization_group_name(&sg.name);
                 }
             }

--- a/packages/server/src/core/bank_rule/tests.rs
+++ b/packages/server/src/core/bank_rule/tests.rs
@@ -6,86 +6,86 @@ use crate::core::degree_status::DegreeStatus;
 use crate::core::tests::create_degree_status;
 use crate::core::types::{Requirement, SpecializationGroup, SpecializationGroups};
 use crate::create_bank_rule_handler;
-use crate::resources::course::{Course, CourseState, CourseStatus, Grade};
+use crate::resources::course::{Course, CourseId, CourseState, CourseStatus, Grade};
 
-static COURSES: LazyLock<HashMap<String, Course>> = LazyLock::new(|| {
+static COURSES: LazyLock<HashMap<CourseId, Course>> = LazyLock::new(|| {
     HashMap::from([
         (
-            "104031".to_string(),
+            CourseId::new("104031"),
             Course {
-                id: "104031".to_string(),
+                id: CourseId::new("104031"),
                 credit: 5.5,
                 name: "infi1m".to_string(),
                 tags: None,
             },
         ),
         (
-            "104166".to_string(),
+            CourseId::new("104166"),
             Course {
-                id: "104166".to_string(),
+                id: CourseId::new("104166"),
                 credit: 5.5,
                 name: "Algebra alef".to_string(),
                 tags: None,
             },
         ),
         (
-            "114052".to_string(),
+            CourseId::new("114052"),
             Course {
-                id: "114052".to_string(),
+                id: CourseId::new("114052"),
                 credit: 3.5,
                 name: "פיסיקה 2".to_string(),
                 tags: None,
             },
         ),
         (
-            "114054".to_string(),
+            CourseId::new("114054"),
             Course {
-                id: "114054".to_string(),
+                id: CourseId::new("114054"),
                 credit: 3.5,
                 name: "פיסיקה 3".to_string(),
                 tags: None,
             },
         ),
         (
-            "236303".to_string(),
+            CourseId::new("236303"),
             Course {
-                id: "236303".to_string(),
+                id: CourseId::new("236303"),
                 credit: 3.0,
                 name: "project1".to_string(),
                 tags: None,
             },
         ),
         (
-            "236512".to_string(),
+            CourseId::new("236512"),
             Course {
-                id: "236512".to_string(),
+                id: CourseId::new("236512"),
                 credit: 3.0,
                 name: "project2".to_string(),
                 tags: None,
             },
         ),
         (
-            "1".to_string(),
+            CourseId::new("11111111"),
             Course {
-                id: "1".to_string(),
+                id: CourseId::new("11111111"),
                 credit: 1.0,
                 name: "".to_string(),
                 tags: None,
             },
         ),
         (
-            "2".to_string(),
+            CourseId::new("22222222"),
             Course {
-                id: "2".to_string(),
+                id: CourseId::new("22222222"),
                 credit: 2.0,
                 name: "".to_string(),
                 tags: None,
             },
         ),
         (
-            "3".to_string(),
+            CourseId::new("33333333"),
             Course {
-                id: "3".to_string(),
+                id: CourseId::new("33333333"),
                 credit: 3.0,
                 name: "".to_string(),
                 tags: None,
@@ -100,11 +100,11 @@ async fn test_rule_all() {
     let mut degree_status = create_degree_status();
     let bank_name = "hova".to_string();
     let course_list = vec![
-        "104031".to_string(),
-        "104166".to_string(),
-        "1".to_string(),
-        "2".to_string(),
-        "3".to_string(),
+        CourseId::new("104031"),
+        CourseId::new("104166"),
+        CourseId::new("11111111"),
+        CourseId::new("22222222"),
+        CourseId::new("33333333"),
     ];
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 0.0, 0);
@@ -122,19 +122,19 @@ async fn test_rule_all() {
     );
 
     // check it adds the not completed courses in the hove bank
-    assert_eq!(degree_status.course_statuses[8].course.id, "1".to_string());
+    assert_eq!(*degree_status.course_statuses[8].course.id, *"11111111");
     assert!(matches!(
         degree_status.course_statuses[8].state,
         Some(CourseState::NotComplete)
     ));
 
-    assert_eq!(degree_status.course_statuses[9].course.id, "2".to_string());
+    assert_eq!(*degree_status.course_statuses[9].course.id, *"22222222");
     assert!(matches!(
         degree_status.course_statuses[9].state,
         Some(CourseState::NotComplete)
     ));
 
-    assert_eq!(degree_status.course_statuses[10].course.id, "3".to_string());
+    assert_eq!(*degree_status.course_statuses[10].course.id, *"33333333");
     assert!(matches!(
         degree_status.course_statuses[10].state,
         Some(CourseState::NotComplete)
@@ -149,10 +149,10 @@ async fn test_rule_accumulate_credit() {
     let mut degree_status = create_degree_status();
     let bank_name = "reshima a".to_string();
     let course_list = vec![
-        "236303".to_string(),
-        "236512".to_string(),
-        "1".to_string(),
-        "2".to_string(),
+        CourseId::new("236303"),
+        CourseId::new("236512"),
+        CourseId::new("11111111"),
+        CourseId::new("22222222"),
     ];
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 5.5, 0);
@@ -184,10 +184,10 @@ async fn test_rule_accumulate_courses() {
     let mut degree_status = create_degree_status();
     let bank_name = "Project".to_string();
     let course_list = vec![
-        "236303".to_string(),
-        "236512".to_string(),
-        "1".to_string(),
-        "2".to_string(),
+        CourseId::new("236303"),
+        CourseId::new("236512"),
+        CourseId::new("11111111"),
+        CourseId::new("22222222"),
     ];
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 0.0, 1);
@@ -222,18 +222,18 @@ async fn test_rule_chain() {
     let mut degree_status = create_degree_status();
     let bank_name = "science chain".to_string();
     let course_list = vec![
-        "1".to_string(),
-        "2".to_string(),
-        "114052".to_string(),
-        "5".to_string(),
-        "114054".to_string(),
-        "111111".to_string(),
+        CourseId::new("11111111"),
+        CourseId::new("22222222"),
+        CourseId::new("114052"),
+        CourseId::new("5"),
+        CourseId::new("114054"),
+        CourseId::new("444444"),
     ];
     let mut chains = vec![
-        vec!["1".to_string(), "2".to_string()],
-        vec!["114052".to_string(), "5".to_string()],
-        vec!["222222".to_string(), "114054".to_string()],
-        vec!["114052".to_string(), "111111".to_string()],
+        vec![CourseId::new("11111111"), CourseId::new("22222222")],
+        vec![CourseId::new("114052"), CourseId::new("5")],
+        vec![CourseId::new("22222222"), CourseId::new("114054")],
+        vec![CourseId::new("114052"), CourseId::new("444444")],
     ];
 
     let mut chain_done = Vec::new();
@@ -252,7 +252,7 @@ async fn test_rule_chain() {
 
     // ---------------------------------------------------------------------------
     degree_status = create_degree_status();
-    chains.push(vec!["114052".to_string(), "114054".to_string()]); // user finished the chain [114052, 114054]
+    chains.push(vec![CourseId::new("114052"), CourseId::new("114054")]); // user finished the chain [114052, 114054]
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 0.0, 0);
     let res = handle_bank_rule_processor.chain(&chains, &mut chain_done);
@@ -285,7 +285,7 @@ async fn test_rule_malag() {
     // for debugging
     let mut degree_status = create_degree_status();
     let bank_name = "MALAG".to_string();
-    let course_list = vec!["1".to_string(), "2".to_string()]; // this list shouldn't affect anything
+    let course_list = vec![CourseId::new("11111111"), CourseId::new("22222222")]; // this list shouldn't affect anything
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 0.0, 0);
     let res = handle_bank_rule_processor.malag();
@@ -313,7 +313,7 @@ async fn test_rule_sport() {
     // for debugging
     let mut degree_status = create_degree_status();
     let bank_name = "SPORT".to_string();
-    let course_list = vec!["1".to_string(), "2".to_string()]; // this list shouldn't affect anything
+    let course_list = vec![CourseId::new("11111111"), CourseId::new("22222222")]; // this list shouldn't affect anything
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 0.0, 0);
     let res = handle_bank_rule_processor.sport();
@@ -343,7 +343,7 @@ async fn test_specialization_group() {
         course_statuses: vec![
             CourseStatus {
                 course: Course {
-                    id: "236334".to_string(),
+                    id: CourseId::new("236334"),
                     credit: 5.5,
                     name: "".to_string(),
                     tags: None,
@@ -354,7 +354,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "044202".to_string(),
+                    id: CourseId::new("044202"),
                     credit: 5.5,
                     name: "".to_string(),
                     tags: None,
@@ -365,7 +365,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "236374".to_string(),
+                    id: CourseId::new("236374"),
                     credit: 3.5,
                     name: "".to_string(),
                     tags: None,
@@ -376,7 +376,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "044198".to_string(),
+                    id: CourseId::new("044198"),
                     credit: 3.0,
                     name: "".to_string(),
                     tags: None,
@@ -387,7 +387,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "236501".to_string(),
+                    id: CourseId::new("236501"),
                     credit: 3.0,
                     name: "".to_string(),
                     tags: None,
@@ -398,7 +398,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "236329".to_string(),
+                    id: CourseId::new("236329"),
                     credit: 2.0,
                     name: "".to_string(),
                     tags: None,
@@ -409,7 +409,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "234325".to_string(),
+                    id: CourseId::new("234325"),
                     credit: 1.0,
                     name: "".to_string(),
                     tags: None,
@@ -420,7 +420,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "044191".to_string(),
+                    id: CourseId::new("044191"),
                     credit: 1.0,
                     name: "".to_string(),
                     tags: None,
@@ -431,7 +431,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "046206".to_string(),
+                    id: CourseId::new("046206"),
                     credit: 3.5,
                     name: "".to_string(),
                     tags: None,
@@ -442,7 +442,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "236319".to_string(),
+                    id: CourseId::new("236319"),
                     credit: 3.5,
                     name: "".to_string(),
                     tags: None,
@@ -453,7 +453,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "236321".to_string(),
+                    id: CourseId::new("236321"),
                     credit: 3.5,
                     name: "".to_string(),
                     tags: None,
@@ -464,7 +464,7 @@ async fn test_specialization_group() {
             },
             CourseStatus {
                 course: Course {
-                    id: "236322".to_string(),
+                    id: CourseId::new("236322"),
                     credit: 3.5,
                     name: "".to_string(),
                     tags: None,
@@ -479,18 +479,18 @@ async fn test_specialization_group() {
         total_credit: 0.0,
     };
     let course_list = vec![
-        "236334".to_string(),
-        "044202".to_string(),
-        "046206".to_string(),
-        "236374".to_string(),
-        "044198".to_string(),
-        "236501".to_string(),
-        "236329".to_string(),
-        "234325".to_string(),
-        "044191".to_string(),
-        "236319".to_string(),
-        "236321".to_string(),
-        "236322".to_string(),
+        CourseId::new("236334"),
+        CourseId::new("044202"),
+        CourseId::new("046206"),
+        CourseId::new("236374"),
+        CourseId::new("044198"),
+        CourseId::new("236501"),
+        CourseId::new("236329"),
+        CourseId::new("234325"),
+        CourseId::new("044191"),
+        CourseId::new("236319"),
+        CourseId::new("236321"),
+        CourseId::new("236322"),
     ];
     let sgs = SpecializationGroups {
         groups_list: vec![
@@ -503,9 +503,9 @@ async fn test_specialization_group() {
                     "046336", "046265",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
-                mandatory: Some(vec![vec!["236334".to_string(), "236357".to_string()]]),
+                mandatory: Some(vec![vec![CourseId::new("236334"), CourseId::new("236357")]]),
             },
             SpecializationGroup {
                 name: "תורת התקשורת".to_string(),
@@ -516,11 +516,11 @@ async fn test_specialization_group() {
                     "236520",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![
-                    vec!["044202".to_string()],
-                    vec!["046206".to_string(), "046204".to_string()],
+                    vec![CourseId::new("044202")],
+                    vec![CourseId::new("046206"), CourseId::new("046204")],
                 ]),
             },
             SpecializationGroup {
@@ -531,9 +531,9 @@ async fn test_specialization_group() {
                     "236506", "236525", "236520", "236522", "236719", "236760", "236990",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
-                mandatory: Some(vec![vec!["236343".to_string()]]),
+                mandatory: Some(vec![vec![CourseId::new("236343")]]),
             },
             SpecializationGroup {
                 name: "עיבוד אותות ותמונות".to_string(),
@@ -544,11 +544,11 @@ async fn test_specialization_group() {
                     "236862",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![
-                    vec!["044198".to_string()],
-                    vec!["044202".to_string(), "236860".to_string()],
+                    vec![CourseId::new("044198")],
+                    vec![CourseId::new("044202"), CourseId::new("236860")],
                 ]),
             },
             SpecializationGroup {
@@ -559,12 +559,12 @@ async fn test_specialization_group() {
                     "236760", "046194", "236329", "236861", "236873", "236941", "236860", "236862",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![vec![
-                    "234325".to_string(),
-                    "236501".to_string(),
-                    "236927".to_string(),
+                    CourseId::new("234325"),
+                    CourseId::new("236501"),
+                    CourseId::new("236927"),
                 ]]),
             },
             SpecializationGroup {
@@ -575,9 +575,12 @@ async fn test_specialization_group() {
                     "046187", "046189", "046773", "046851", "046880",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
-                mandatory: Some(vec![vec!["044231".to_string()], vec!["046237".to_string()]]),
+                mandatory: Some(vec![
+                    vec![CourseId::new("044231")],
+                    vec![CourseId::new("046237")],
+                ]),
             },
             SpecializationGroup {
                 name: "מערכות תוכנה ותכנות מתקדם".to_string(),
@@ -588,7 +591,7 @@ async fn test_specialization_group() {
                     "046275", "236278",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
                 mandatory: None,
             },
@@ -600,9 +603,9 @@ async fn test_specialization_group() {
                     "236330", "236756", "236927",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
-                mandatory: Some(vec![vec!["044191".to_string()]]),
+                mandatory: Some(vec![vec![CourseId::new("044191")]]),
             },
             SpecializationGroup {
                 name: "שפות תכנות, שפות פורמליות וטבעיות".to_string(),
@@ -612,9 +615,9 @@ async fn test_specialization_group() {
                     "236780",
                 ]
                 .into_iter()
-                .map(|c| c.to_string())
+                .map(|c| CourseId::new(c))
                 .collect::<Vec<_>>(),
-                mandatory: Some(vec![vec!["234129".to_string()]]),
+                mandatory: Some(vec![vec![CourseId::new("234129")]]),
             },
         ],
         groups_number: 3,

--- a/packages/server/src/core/bank_rule/tests.rs
+++ b/packages/server/src/core/bank_rule/tests.rs
@@ -503,7 +503,7 @@ async fn test_specialization_group() {
                     "046336", "046265",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![vec![CourseId::new("236334"), CourseId::new("236357")]]),
             },
@@ -516,7 +516,7 @@ async fn test_specialization_group() {
                     "236520",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![
                     vec![CourseId::new("044202")],
@@ -531,7 +531,7 @@ async fn test_specialization_group() {
                     "236506", "236525", "236520", "236522", "236719", "236760", "236990",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![vec![CourseId::new("236343")]]),
             },
@@ -544,7 +544,7 @@ async fn test_specialization_group() {
                     "236862",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![
                     vec![CourseId::new("044198")],
@@ -559,7 +559,7 @@ async fn test_specialization_group() {
                     "236760", "046194", "236329", "236861", "236873", "236941", "236860", "236862",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![vec![
                     CourseId::new("234325"),
@@ -575,7 +575,7 @@ async fn test_specialization_group() {
                     "046187", "046189", "046773", "046851", "046880",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![
                     vec![CourseId::new("044231")],
@@ -591,7 +591,7 @@ async fn test_specialization_group() {
                     "046275", "236278",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: None,
             },
@@ -603,7 +603,7 @@ async fn test_specialization_group() {
                     "236330", "236756", "236927",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![vec![CourseId::new("044191")]]),
             },
@@ -615,7 +615,7 @@ async fn test_specialization_group() {
                     "236780",
                 ]
                 .into_iter()
-                .map(|c| CourseId::new(c))
+                .map(CourseId::new)
                 .collect::<Vec<_>>(),
                 mandatory: Some(vec![vec![CourseId::new("234129")]]),
             },

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -67,11 +67,10 @@ impl DegreeStatus {
             })
     }
 
-    pub fn fill_tags(&mut self, courses: &[Course]) {
+    pub fn fill_tags(&mut self, courses: &HashMap<CourseId, Course>) {
         self.course_statuses.iter_mut().for_each(|course_status| {
             course_status.course.tags = courses
-                .iter()
-                .find(|course| course.id == course_status.course.id)
+                .get(&course_status.course.id)
                 .and_then(|course| course.tags.clone());
         });
     }

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -67,14 +67,6 @@ impl DegreeStatus {
             })
     }
 
-    pub fn fill_tags(&mut self, courses: &HashMap<CourseId, Course>) {
-        self.course_statuses.iter_mut().for_each(|course_status| {
-            course_status.course.tags = courses
-                .get(&course_status.course.id)
-                .and_then(|course| course.tags.clone());
-        });
-    }
-
     pub fn get_all_taken_courses_for_bank(&self, bank_name: &str) -> Vec<CourseId> {
         self.course_statuses
             .iter()
@@ -126,9 +118,8 @@ impl DegreeStatusHandler<'_> {
 }
 
 impl DegreeStatus {
-    pub fn compute(&mut self, mut catalog: Catalog, courses: HashMap<CourseId, Course>) {
-        // prepare the data for degree status computation
-        self.preprocess(&mut catalog, &courses);
+    pub fn compute(&mut self, mut catalog: Catalog, mut courses: HashMap<CourseId, Course>) {
+        self.preprocess(&mut catalog, &mut courses);
 
         let course_banks = catalog.get_bank_traversal_order();
 

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -22,18 +22,18 @@ pub struct DegreeStatus {
 }
 
 impl DegreeStatus {
-    pub fn get_course_status(&self, id: &str) -> Option<&CourseStatus> {
+    pub fn get_course_status(&self, id: &CourseId) -> Option<&CourseStatus> {
         // returns the first course_status with the given id
         self.course_statuses
             .iter()
-            .find(|&course_status| course_status.course.id == id)
+            .find(|&course_status| course_status.course.id == *id)
     }
 
-    pub fn get_mut_course_status(&mut self, id: &str) -> Option<&mut CourseStatus> {
+    pub fn get_mut_course_status(&mut self, id: &CourseId) -> Option<&mut CourseStatus> {
         // returns the first course_status with the given id
         self.course_statuses
             .iter_mut()
-            .find(|course_status| course_status.course.id == id)
+            .find(|course_status| course_status.course.id == *id)
     }
 
     // This function sets the state for all courses where their state is "in progress" to "complete"

--- a/packages/server/src/core/degree_status/postprocessing.rs
+++ b/packages/server/src/core/degree_status/postprocessing.rs
@@ -3,7 +3,7 @@ use crate::{
     core::messages,
     resources::{
         catalog::Catalog,
-        course::{CourseStatus, Grade},
+        course::{CourseId, CourseStatus, Grade},
     },
 };
 
@@ -50,7 +50,7 @@ impl DegreeStatus {
             .count();
 
         let technical_english_advanced_b_course_status =
-            self.get_course_status(TECHNICAL_ENGLISH_ADVANCED_B);
+            self.get_course_status(&CourseId::new(TECHNICAL_ENGLISH_ADVANCED_B_ID));
 
         let Some(technical_english_advanced_b_course_status) =
             technical_english_advanced_b_course_status

--- a/packages/server/src/core/degree_status/postprocessing_tests.rs
+++ b/packages/server/src/core/degree_status/postprocessing_tests.rs
@@ -5,7 +5,7 @@ use crate::{
     core::{messages, types::Rule},
     resources::{
         catalog::{Catalog, Faculty},
-        course::{Course, CourseBank, CourseState, CourseStatus, Grade, Tag},
+        course::{Course, CourseBank, CourseId, CourseState, CourseStatus, Grade, Tag},
     },
 };
 
@@ -14,7 +14,7 @@ use super::*;
 fn english_course(id: &str, grade: Grade) -> CourseStatus {
     CourseStatus {
         course: Course {
-            id: id.to_string(),
+            id: CourseId::new(id),
             credit: 2.0,
             name: id.to_string(),
             tags: Some(vec![Tag::English]),
@@ -28,7 +28,7 @@ fn english_course(id: &str, grade: Grade) -> CourseStatus {
 fn regular_course(id: &str, bank: &str, grade: Grade, repeats: usize) -> CourseStatus {
     CourseStatus {
         course: Course {
-            id: id.to_string(),
+            id: CourseId::new(id),
             credit: 3.0,
             name: id.to_string(),
             tags: None,
@@ -61,7 +61,7 @@ fn catalog(name: &str, faculty: Faculty, course_banks: Vec<CourseBank>) -> Catal
 fn english_requirement_is_not_checked_for_old_catalog_years() {
     let mut degree_status = DegreeStatus {
         course_statuses: vec![english_course(
-            consts::TECHNICAL_ENGLISH_ADVANCED_B,
+            consts::TECHNICAL_ENGLISH_ADVANCED_B_ID,
             Grade::ExemptionWithCredit,
         )],
         ..Default::default()
@@ -77,7 +77,7 @@ fn english_requirement_is_not_checked_for_old_catalog_years() {
 fn english_requirement_warns_exempt_students_with_missing_english_content() {
     let mut degree_status = DegreeStatus {
         course_statuses: vec![english_course(
-            consts::TECHNICAL_ENGLISH_ADVANCED_B,
+            consts::TECHNICAL_ENGLISH_ADVANCED_B_ID,
             Grade::ExemptionWithoutCredit,
         )],
         ..Default::default()
@@ -97,7 +97,7 @@ fn medicine_postprocessing_reports_zero_average_when_no_numeric_grades() {
     let mut degree_status = DegreeStatus {
         course_statuses: vec![CourseStatus {
             course: Course {
-                id: "med".to_string(),
+                id: CourseId::new("med"),
                 credit: 3.0,
                 name: "med".to_string(),
                 tags: None,
@@ -178,7 +178,7 @@ fn medicine_postprocessing_flags_course_repetition_violations() {
             degree_status
                 .course_statuses
                 .iter()
-                .filter(|cs| cs.course.id == "med-repeat")
+                .filter(|cs| *cs.course.id == *"med-repeat")
                 .collect(),
         )
     }));

--- a/packages/server/src/core/degree_status/preprocessing.rs
+++ b/packages/server/src/core/degree_status/preprocessing.rs
@@ -4,7 +4,7 @@ use crate::{
     core::messages,
     resources::{
         catalog::Catalog,
-        course::{Course, CourseId, CourseState},
+        course::{to_8digit, Course, CourseId, CourseState},
     },
 };
 
@@ -78,17 +78,11 @@ impl DegreeStatus {
         self.remove_irrelevant_courses_from_catalog(catalog);
     }
 
-    /// Convert a 6-digit course ID to 8-digit format by prepending "0" to each 3-digit half.
-    /// e.g. "114075" -> "01140075", "234114" -> "02340114"
-    fn to_8digit(id: &str) -> String {
-        format!("0{}0{}", &id[..3], &id[3..])
-    }
-
     /// Normalize all 6-digit course IDs to 8-digit format in course_statuses.
     fn normalize_course_ids(&mut self) {
         for cs in self.course_statuses.iter_mut() {
-            if cs.course.id.len() == 6 && cs.course.id.chars().all(|c| c.is_ascii_digit()) {
-                cs.course.id = Self::to_8digit(&cs.course.id);
+            if cs.course.id.len() == 6 {
+                cs.course.id = to_8digit(&cs.course.id);
             }
         }
     }
@@ -151,9 +145,10 @@ impl DegreeStatus {
     }
 
     pub fn preprocess(&mut self, catalog: &mut Catalog, courses: &HashMap<CourseId, Course>) {
-        if catalog.year() >= 2024 {
-            self.normalize_course_ids();
-        }
+        // Always normalize both student courses and catalog to 8-digit format
+        self.normalize_course_ids();
+        catalog.normalize_course_ids();
+
         self.reset(catalog);
 
         self.course_statuses.sort_by(|c1, c2| {

--- a/packages/server/src/core/degree_status/preprocessing.rs
+++ b/packages/server/src/core/degree_status/preprocessing.rs
@@ -4,7 +4,7 @@ use crate::{
     core::messages,
     resources::{
         catalog::Catalog,
-        course::{to_8digit, Course, CourseId, CourseState},
+        course::{Course, CourseId, CourseState},
     },
 };
 
@@ -78,15 +78,6 @@ impl DegreeStatus {
         self.remove_irrelevant_courses_from_catalog(catalog);
     }
 
-    /// Normalize all 6-digit course IDs to 8-digit format in course_statuses.
-    fn normalize_course_ids(&mut self) {
-        for cs in self.course_statuses.iter_mut() {
-            if cs.course.id.len() == 6 {
-                cs.course.id = to_8digit(&cs.course.id);
-            }
-        }
-    }
-
     fn get_all_student_replacements_and_set_msg(
         &mut self,
         catalog: &Catalog,
@@ -95,7 +86,7 @@ impl DegreeStatus {
         let mut student_replacements = HashMap::new();
         self.course_statuses.iter_mut().for_each(|course_status| {
             let mut find_replacement =
-                |replacements: &HashMap<String, Vec<String>>,
+                |replacements: &HashMap<CourseId, Vec<CourseId>>,
                  replacements_msg: fn(&Course) -> String| {
                     replacements
                         .iter()
@@ -145,10 +136,6 @@ impl DegreeStatus {
     }
 
     pub fn preprocess(&mut self, catalog: &mut Catalog, courses: &HashMap<CourseId, Course>) {
-        // Always normalize both student courses and catalog to 8-digit format
-        self.normalize_course_ids();
-        catalog.normalize_course_ids();
-
         self.reset(catalog);
 
         self.course_statuses.sort_by(|c1, c2| {

--- a/packages/server/src/core/degree_status/preprocessing.rs
+++ b/packages/server/src/core/degree_status/preprocessing.rs
@@ -135,7 +135,27 @@ impl DegreeStatus {
             });
     }
 
-    pub fn preprocess(&mut self, catalog: &mut Catalog, courses: &HashMap<CourseId, Course>) {
+    // Merge the student courses with the course list
+    fn merge_courses(&self, courses: &mut HashMap<CourseId, Course>) {
+        for cs in &self.course_statuses {
+            courses
+                .entry(cs.course.id.clone())
+                .or_insert_with(|| cs.course.clone());
+        }
+    }
+
+    // Fill students courses with the relevant tags
+    fn fill_tags(&mut self, courses: &HashMap<CourseId, Course>) {
+        self.course_statuses.iter_mut().for_each(|course_status| {
+            course_status.course.tags = courses
+                .get(&course_status.course.id)
+                .and_then(|course| course.tags.clone());
+        });
+    }
+
+    pub fn preprocess(&mut self, catalog: &mut Catalog, courses: &mut HashMap<CourseId, Course>) {
+        self.merge_courses(courses);
+        self.fill_tags(courses);
         self.reset(catalog);
 
         self.course_statuses.sort_by(|c1, c2| {

--- a/packages/server/src/core/degree_status/preprocessing.rs
+++ b/packages/server/src/core/degree_status/preprocessing.rs
@@ -147,6 +147,8 @@ impl DegreeStatus {
         });
 
         self.replace_student_course_with_courses_in_catalog(catalog, courses);
+
+        catalog.enrich_with_prefix_courses(&self.course_statuses);
     }
 }
 

--- a/packages/server/src/core/degree_status/preprocessing_tests.rs
+++ b/packages/server/src/core/degree_status/preprocessing_tests.rs
@@ -157,3 +157,148 @@ fn preprocess_removes_irrelevant_courses_from_catalog_mapping() {
     assert!(catalog.course_to_bank.contains_key("dup"));
     assert_eq!(degree_status.course_statuses[0].course.id, "dup");
 }
+
+// ---- 6-digit → 8-digit normalization tests ----
+
+#[test]
+fn preprocess_normalizes_standard_6digit_course_id_to_8digit() {
+    // Standard: ABCDEF → 0ABC0DEF
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![cs(
+            "234107",
+            Some(CourseState::Complete),
+            true,
+            Some("חורף_1"),
+            Some("hova"),
+        )],
+        ..Default::default()
+    };
+    let mut catalog = make_catalog();
+
+    degree_status.preprocess(&mut catalog, &HashMap::new());
+
+    assert_eq!(degree_status.course_statuses[0].course.id, "02340107");
+}
+
+#[test]
+fn preprocess_normalizes_nonstandard_6digit_course_id_to_8digit() {
+    // Non-standard (prefix 51): ABCDEF → AB0C0DEF
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![cs(
+            "514003",
+            Some(CourseState::Complete),
+            true,
+            Some("חורף_1"),
+            Some("hova"),
+        )],
+        ..Default::default()
+    };
+    let mut catalog = make_catalog();
+
+    degree_status.preprocess(&mut catalog, &HashMap::new());
+
+    assert_eq!(degree_status.course_statuses[0].course.id, "51040003");
+}
+
+#[test]
+fn preprocess_does_not_modify_already_8digit_course_id() {
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![cs(
+            "02340107",
+            Some(CourseState::Complete),
+            true,
+            Some("חורף_1"),
+            Some("hova"),
+        )],
+        ..Default::default()
+    };
+    let mut catalog = make_catalog();
+
+    degree_status.preprocess(&mut catalog, &HashMap::new());
+
+    assert_eq!(degree_status.course_statuses[0].course.id, "02340107");
+}
+
+#[test]
+fn preprocess_normalizes_catalog_6digit_keys_to_8digit() {
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![cs(
+            "02340107",
+            Some(CourseState::Complete),
+            true,
+            Some("חורף_1"),
+            Some("hova"),
+        )],
+        ..Default::default()
+    };
+    let mut catalog = make_catalog();
+    catalog
+        .course_to_bank
+        .insert("234107".to_string(), "hova".to_string());
+
+    degree_status.preprocess(&mut catalog, &HashMap::new());
+
+    assert!(!catalog.course_to_bank.contains_key("234107"));
+    assert!(catalog.course_to_bank.contains_key("02340107"));
+}
+
+#[test]
+fn preprocess_normalizes_catalog_replacements_keys_and_values() {
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![cs(
+            "02340107",
+            Some(CourseState::Complete),
+            true,
+            Some("חורף_1"),
+            Some("hova"),
+        )],
+        ..Default::default()
+    };
+    let mut catalog = make_catalog();
+    catalog
+        .catalog_replacements
+        .insert("234107".to_string(), vec!["514003".to_string()]);
+
+    degree_status.preprocess(&mut catalog, &HashMap::new());
+
+    assert!(!catalog.catalog_replacements.contains_key("234107"));
+    let values = catalog.catalog_replacements.get("02340107").unwrap();
+    assert_eq!(values, &vec!["51040003".to_string()]);
+}
+
+#[test]
+fn preprocess_normalizes_all_nonstandard_prefixes() {
+    // Verify each non-standard prefix (52, 61, 97) converts correctly
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![
+            cs("521234", Some(CourseState::Complete), true, Some("חורף_1"), None),
+            cs("611234", Some(CourseState::Complete), true, Some("אביב_1"), None),
+            cs("971234", Some(CourseState::Complete), true, Some("קיץ_1.5"), None),
+        ],
+        ..Default::default()
+    };
+    let mut catalog = make_catalog();
+
+    degree_status.preprocess(&mut catalog, &HashMap::new());
+
+    assert_eq!(degree_status.course_statuses[0].course.id, "52010234");
+    assert_eq!(degree_status.course_statuses[1].course.id, "61010234");
+    assert_eq!(degree_status.course_statuses[2].course.id, "97010234");
+}
+
+#[test]
+fn preprocess_normalizes_mixed_6digit_and_8digit_courses() {
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![
+            cs("234107", Some(CourseState::Complete), true, Some("חורף_1"), None),
+            cs("02360218", Some(CourseState::Complete), true, Some("אביב_1"), None),
+        ],
+        ..Default::default()
+    };
+    let mut catalog = make_catalog();
+
+    degree_status.preprocess(&mut catalog, &HashMap::new());
+
+    assert_eq!(degree_status.course_statuses[0].course.id, "02340107");
+    assert_eq!(degree_status.course_statuses[1].course.id, "02360218");
+}

--- a/packages/server/src/core/degree_status/preprocessing_tests.rs
+++ b/packages/server/src/core/degree_status/preprocessing_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     core::types::Rule,
     resources::{
         catalog::{Catalog, Faculty},
-        course::{Course, CourseBank, CourseState, CourseStatus, Grade},
+        course::{Course, CourseBank, CourseId, CourseState, CourseStatus, Grade},
     },
 };
 
@@ -19,7 +19,7 @@ fn cs(
 ) -> CourseStatus {
     CourseStatus {
         course: Course {
-            id: id.to_string(),
+            id: CourseId::new(id),
             credit: 1.0,
             name: id.to_string(),
             tags: None,
@@ -47,8 +47,8 @@ fn make_catalog() -> Catalog {
         }],
         credit_overflows: vec![],
         course_to_bank: HashMap::from([
-            ("alg".to_string(), "hova".to_string()),
-            ("dup".to_string(), "hova".to_string()),
+            (CourseId::new("alg"), "hova".to_string()),
+            (CourseId::new("dup"), "hova".to_string()),
         ]),
         catalog_replacements: HashMap::new(),
         common_replacements: HashMap::new(),
@@ -81,7 +81,7 @@ fn preprocess_removes_irrelevant_duplicate_when_user_added_same_course() {
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
     assert_eq!(degree_status.course_statuses.len(), 1);
-    assert_eq!(degree_status.course_statuses[0].course.id, "dup");
+    assert_eq!(*degree_status.course_statuses[0].course.id, *"dup");
     assert_ne!(
         degree_status.course_statuses[0].state,
         Some(CourseState::Irrelevant)
@@ -120,10 +120,25 @@ fn preprocess_clears_type_for_unmodified_and_irrelevant_courses() {
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
-    assert_eq!(degree_status.get_course_status("alg").unwrap().r#type, None);
-    assert_eq!(degree_status.get_course_status("dup").unwrap().r#type, None);
     assert_eq!(
-        degree_status.get_course_status("ok").unwrap().r#type,
+        degree_status
+            .get_course_status(&CourseId::new("alg"))
+            .unwrap()
+            .r#type,
+        None
+    );
+    assert_eq!(
+        degree_status
+            .get_course_status(&CourseId::new("dup"))
+            .unwrap()
+            .r#type,
+        None
+    );
+    assert_eq!(
+        degree_status
+            .get_course_status(&CourseId::new("ok"))
+            .unwrap()
+            .r#type,
         Some("hova".to_string())
     );
 }
@@ -155,7 +170,7 @@ fn preprocess_removes_irrelevant_courses_from_catalog_mapping() {
 
     assert!(!catalog.course_to_bank.contains_key("alg"));
     assert!(catalog.course_to_bank.contains_key("dup"));
-    assert_eq!(degree_status.course_statuses[0].course.id, "dup");
+    assert_eq!(*degree_status.course_statuses[0].course.id, *"dup");
 }
 
 // ---- 6-digit → 8-digit normalization tests ----
@@ -177,7 +192,7 @@ fn preprocess_normalizes_standard_6digit_course_id_to_8digit() {
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
-    assert_eq!(degree_status.course_statuses[0].course.id, "02340107");
+    assert_eq!(*degree_status.course_statuses[0].course.id, *"02340107");
 }
 
 #[test]
@@ -197,7 +212,7 @@ fn preprocess_normalizes_nonstandard_6digit_course_id_to_8digit() {
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
-    assert_eq!(degree_status.course_statuses[0].course.id, "51040003");
+    assert_eq!(*degree_status.course_statuses[0].course.id, *"51040003");
 }
 
 #[test]
@@ -216,7 +231,7 @@ fn preprocess_does_not_modify_already_8digit_course_id() {
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
-    assert_eq!(degree_status.course_statuses[0].course.id, "02340107");
+    assert_eq!(*degree_status.course_statuses[0].course.id, *"02340107");
 }
 
 #[test]
@@ -234,7 +249,7 @@ fn preprocess_normalizes_catalog_6digit_keys_to_8digit() {
     let mut catalog = make_catalog();
     catalog
         .course_to_bank
-        .insert("234107".to_string(), "hova".to_string());
+        .insert(CourseId::new("234107"), "hova".to_string());
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
@@ -257,13 +272,13 @@ fn preprocess_normalizes_catalog_replacements_keys_and_values() {
     let mut catalog = make_catalog();
     catalog
         .catalog_replacements
-        .insert("234107".to_string(), vec!["514003".to_string()]);
+        .insert(CourseId::new("234107"), vec![CourseId::new("514003")]);
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
     assert!(!catalog.catalog_replacements.contains_key("234107"));
     let values = catalog.catalog_replacements.get("02340107").unwrap();
-    assert_eq!(values, &vec!["51040003".to_string()]);
+    assert_eq!(values, &vec![CourseId::new("51040003")]);
 }
 
 #[test]
@@ -271,9 +286,27 @@ fn preprocess_normalizes_all_nonstandard_prefixes() {
     // Verify each non-standard prefix (52, 61, 97) converts correctly
     let mut degree_status = DegreeStatus {
         course_statuses: vec![
-            cs("521234", Some(CourseState::Complete), true, Some("חורף_1"), None),
-            cs("611234", Some(CourseState::Complete), true, Some("אביב_1"), None),
-            cs("971234", Some(CourseState::Complete), true, Some("קיץ_1.5"), None),
+            cs(
+                "521234",
+                Some(CourseState::Complete),
+                true,
+                Some("חורף_1"),
+                None,
+            ),
+            cs(
+                "611234",
+                Some(CourseState::Complete),
+                true,
+                Some("אביב_1"),
+                None,
+            ),
+            cs(
+                "971234",
+                Some(CourseState::Complete),
+                true,
+                Some("קיץ_1.5"),
+                None,
+            ),
         ],
         ..Default::default()
     };
@@ -281,17 +314,29 @@ fn preprocess_normalizes_all_nonstandard_prefixes() {
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
-    assert_eq!(degree_status.course_statuses[0].course.id, "52010234");
-    assert_eq!(degree_status.course_statuses[1].course.id, "61010234");
-    assert_eq!(degree_status.course_statuses[2].course.id, "97010234");
+    assert_eq!(*degree_status.course_statuses[0].course.id, *"52010234");
+    assert_eq!(*degree_status.course_statuses[1].course.id, *"61010234");
+    assert_eq!(*degree_status.course_statuses[2].course.id, *"97010234");
 }
 
 #[test]
 fn preprocess_normalizes_mixed_6digit_and_8digit_courses() {
     let mut degree_status = DegreeStatus {
         course_statuses: vec![
-            cs("234107", Some(CourseState::Complete), true, Some("חורף_1"), None),
-            cs("02360218", Some(CourseState::Complete), true, Some("אביב_1"), None),
+            cs(
+                "234107",
+                Some(CourseState::Complete),
+                true,
+                Some("חורף_1"),
+                None,
+            ),
+            cs(
+                "02360218",
+                Some(CourseState::Complete),
+                true,
+                Some("אביב_1"),
+                None,
+            ),
         ],
         ..Default::default()
     };
@@ -299,6 +344,6 @@ fn preprocess_normalizes_mixed_6digit_and_8digit_courses() {
 
     degree_status.preprocess(&mut catalog, &HashMap::new());
 
-    assert_eq!(degree_status.course_statuses[0].course.id, "02340107");
-    assert_eq!(degree_status.course_statuses[1].course.id, "02360218");
+    assert_eq!(*degree_status.course_statuses[0].course.id, *"02340107");
+    assert_eq!(*degree_status.course_statuses[1].course.id, *"02360218");
 }

--- a/packages/server/src/core/degree_status/preprocessing_tests.rs
+++ b/packages/server/src/core/degree_status/preprocessing_tests.rs
@@ -78,7 +78,7 @@ fn preprocess_removes_irrelevant_duplicate_when_user_added_same_course() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert_eq!(degree_status.course_statuses.len(), 1);
     assert_eq!(*degree_status.course_statuses[0].course.id, *"dup");
@@ -118,7 +118,7 @@ fn preprocess_clears_type_for_unmodified_and_irrelevant_courses() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert_eq!(
         degree_status
@@ -166,7 +166,7 @@ fn preprocess_removes_irrelevant_courses_from_catalog_mapping() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert!(!catalog.course_to_bank.contains_key("alg"));
     assert!(catalog.course_to_bank.contains_key("dup"));
@@ -190,7 +190,7 @@ fn preprocess_normalizes_standard_6digit_course_id_to_8digit() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert_eq!(*degree_status.course_statuses[0].course.id, *"02340107");
 }
@@ -210,7 +210,7 @@ fn preprocess_normalizes_nonstandard_6digit_course_id_to_8digit() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert_eq!(*degree_status.course_statuses[0].course.id, *"51040003");
 }
@@ -229,7 +229,7 @@ fn preprocess_does_not_modify_already_8digit_course_id() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert_eq!(*degree_status.course_statuses[0].course.id, *"02340107");
 }
@@ -251,7 +251,7 @@ fn preprocess_normalizes_catalog_6digit_keys_to_8digit() {
         .course_to_bank
         .insert(CourseId::new("234107"), "hova".to_string());
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert!(!catalog.course_to_bank.contains_key("234107"));
     assert!(catalog.course_to_bank.contains_key("02340107"));
@@ -274,7 +274,7 @@ fn preprocess_normalizes_catalog_replacements_keys_and_values() {
         .catalog_replacements
         .insert(CourseId::new("234107"), vec![CourseId::new("514003")]);
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert!(!catalog.catalog_replacements.contains_key("234107"));
     let values = catalog.catalog_replacements.get("02340107").unwrap();
@@ -312,7 +312,7 @@ fn preprocess_normalizes_all_nonstandard_prefixes() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert_eq!(*degree_status.course_statuses[0].course.id, *"52010234");
     assert_eq!(*degree_status.course_statuses[1].course.id, *"61010234");
@@ -342,7 +342,7 @@ fn preprocess_normalizes_mixed_6digit_and_8digit_courses() {
     };
     let mut catalog = make_catalog();
 
-    degree_status.preprocess(&mut catalog, &HashMap::new());
+    degree_status.preprocess(&mut catalog, &mut HashMap::new());
 
     assert_eq!(*degree_status.course_statuses[0].course.id, *"02340107");
     assert_eq!(*degree_status.course_statuses[1].course.id, *"02360218");

--- a/packages/server/src/core/parser.rs
+++ b/packages/server/src/core/parser.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use crate::{
     error::AppError,
-    resources::course::{Course, CourseStatus, Grade},
+    resources::course::{Course, CourseId, CourseStatus, Grade},
 };
 use std::collections::HashMap;
 
@@ -50,7 +50,7 @@ pub fn parse_copy_paste_data(data: &str) -> Result<Vec<CourseStatus>, AppError> 
         return Err(AppError::Parser("Invalid copy paste data".into()));
     }
 
-    let mut courses = HashMap::<String, CourseStatus>::new();
+    let mut courses = HashMap::<CourseId, CourseStatus>::new();
     let mut asterisk_courses = Vec::<CourseStatus>::new();
     let mut sport_courses = Vec::<CourseStatus>::new();
     let mut semester = String::new();
@@ -109,7 +109,7 @@ pub fn parse_copy_paste_data(data: &str) -> Result<Vec<CourseStatus>, AppError> 
             ..Default::default()
         };
         course_status.set_state();
-        if course_status.course.id.starts_with("394") {
+        if course_status.course.id.starts_with("0394") {
             sport_courses.push(course_status);
             continue;
         }
@@ -239,7 +239,7 @@ fn parse_course_status_pdf_format(
     };
     Ok((
         Course {
-            id,
+            id: CourseId::new(id),
             credit,
             name,
             tags: None,

--- a/packages/server/src/core/parser_tests.rs
+++ b/packages/server/src/core/parser_tests.rs
@@ -1,11 +1,11 @@
-use crate::resources::course::CourseState;
+use crate::resources::course::{CourseId, CourseState};
 
 use super::*;
 
 fn cs(id: &str, grade: Grade, semester: &str) -> CourseStatus {
     let mut course_status = CourseStatus {
         course: Course {
-            id: id.to_string(),
+            id: CourseId::new(id),
             credit: 1.0,
             name: id.to_string(),
             tags: None,
@@ -39,7 +39,7 @@ fn parse_course_status_handles_not_complete_m_variant() {
 
     let (course, grade) = parse_course_status_pdf_format(line, false, false).unwrap();
 
-    assert_eq!(course.id, "234111");
+    assert_eq!(*course.id, *"02340111");
     assert_eq!(course.credit, 3.0);
     assert_eq!(course.name, "(מ) מבני נתונים");
     assert_eq!(grade, Some(Grade::NotComplete));

--- a/packages/server/src/core/parser_v2.rs
+++ b/packages/server/src/core/parser_v2.rs
@@ -423,8 +423,8 @@ fn assign_semester_numbers(raw_courses: Vec<RawCourse>) -> Result<Vec<CourseStat
 
         // 0-credit exemptions (פטור ללא ניקוד) should have no semester,
         // so they are not picked up by bank rules (e.g. elective).
-        let is_zero_credit_exemption = raw.credit == 0.0
-            && matches!(raw.grade, Some(Grade::ExemptionWithoutCredit));
+        let is_zero_credit_exemption =
+            raw.credit == 0.0 && matches!(raw.grade, Some(Grade::ExemptionWithoutCredit));
 
         let mut cs = CourseStatus {
             course: Course {

--- a/packages/server/src/core/parser_v2.rs
+++ b/packages/server/src/core/parser_v2.rs
@@ -421,6 +421,11 @@ fn assign_semester_numbers(raw_courses: Vec<RawCourse>) -> Result<Vec<CourseStat
             .get(&(raw.semester_year, raw.semester_term))
             .cloned();
 
+        // 0-credit exemptions (פטור ללא ניקוד) should have no semester,
+        // so they are not picked up by bank rules (e.g. elective).
+        let is_zero_credit_exemption = raw.credit == 0.0
+            && matches!(raw.grade, Some(Grade::ExemptionWithoutCredit));
+
         let mut cs = CourseStatus {
             course: Course {
                 id: CourseId::new(raw.id),
@@ -428,7 +433,11 @@ fn assign_semester_numbers(raw_courses: Vec<RawCourse>) -> Result<Vec<CourseStat
                 name: raw.name,
                 tags: None,
             },
-            semester,
+            semester: if is_zero_credit_exemption {
+                None
+            } else {
+                semester
+            },
             grade: raw.grade,
             ..Default::default()
         };

--- a/packages/server/src/core/parser_v2.rs
+++ b/packages/server/src/core/parser_v2.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use crate::{
     error::AppError,
-    resources::course::{Course, CourseStatus, Grade},
+    resources::course::{Course, CourseId, CourseStatus, Grade},
 };
 use std::collections::HashMap;
 
@@ -423,7 +423,7 @@ fn assign_semester_numbers(raw_courses: Vec<RawCourse>) -> Result<Vec<CourseStat
 
         let mut cs = CourseStatus {
             course: Course {
-                id: raw.id,
+                id: CourseId::new(raw.id),
                 credit: raw.credit,
                 name: raw.name,
                 tags: None,

--- a/packages/server/src/core/parser_v2_tests.rs
+++ b/packages/server/src/core/parser_v2_tests.rs
@@ -105,7 +105,10 @@ fn chrome_exemption_without_credit_has_no_semester() {
     let cs = find_course(&courses, "01030015").expect("Course 01030015 not found");
     assert_eq!(cs.grade, Some(Grade::ExemptionWithoutCredit));
     assert_eq!(cs.course.credit, 0.0);
-    assert_eq!(cs.semester, None, "0-credit exemption courses should have no semester");
+    assert_eq!(
+        cs.semester, None,
+        "0-credit exemption courses should have no semester"
+    );
 }
 
 #[test]
@@ -133,7 +136,10 @@ fn edge_exemption_without_credit_has_no_semester() {
     let courses = parse_copy_paste_data(&data).unwrap();
     let cs = find_course(&courses, "03240053").expect("Course 03240053 not found");
     assert_eq!(cs.grade, Some(Grade::ExemptionWithoutCredit));
-    assert_eq!(cs.semester, None, "0-credit exemption courses should have no semester");
+    assert_eq!(
+        cs.semester, None,
+        "0-credit exemption courses should have no semester"
+    );
 }
 
 #[test]
@@ -178,7 +184,11 @@ fn chrome_assigns_semester_numbers() {
     for cs in &courses {
         // 0-credit exemptions have no semester by design
         if cs.course.credit == 0.0 && cs.grade == Some(Grade::ExemptionWithoutCredit) {
-            assert!(cs.semester.is_none(), "0-credit exemption course {} should have no semester", cs.course.id);
+            assert!(
+                cs.semester.is_none(),
+                "0-credit exemption course {} should have no semester",
+                cs.course.id
+            );
             continue;
         }
         assert!(

--- a/packages/server/src/core/parser_v2_tests.rs
+++ b/packages/server/src/core/parser_v2_tests.rs
@@ -99,6 +99,16 @@ fn chrome_parses_exemption_without_credit() {
 }
 
 #[test]
+fn chrome_exemption_without_credit_has_no_semester() {
+    let data = get_chrome_data();
+    let courses = parse_copy_paste_data(&data).unwrap();
+    let cs = find_course(&courses, "01030015").expect("Course 01030015 not found");
+    assert_eq!(cs.grade, Some(Grade::ExemptionWithoutCredit));
+    assert_eq!(cs.course.credit, 0.0);
+    assert_eq!(cs.semester, None, "0-credit exemption courses should have no semester");
+}
+
+#[test]
 fn chrome_exemption_without_credit_has_zero_credit() {
     let data = get_chrome_data();
     let courses = parse_copy_paste_data(&data).unwrap();
@@ -115,6 +125,15 @@ fn edge_exemption_without_credit_has_zero_credit() {
     let cs = find_course(&courses, "03240053").expect("Course 03240053 not found");
     assert_eq!(cs.grade, Some(Grade::ExemptionWithoutCredit));
     assert_eq!(cs.course.credit, 0.0);
+}
+
+#[test]
+fn edge_exemption_without_credit_has_no_semester() {
+    let data = get_edge_data();
+    let courses = parse_copy_paste_data(&data).unwrap();
+    let cs = find_course(&courses, "03240053").expect("Course 03240053 not found");
+    assert_eq!(cs.grade, Some(Grade::ExemptionWithoutCredit));
+    assert_eq!(cs.semester, None, "0-credit exemption courses should have no semester");
 }
 
 #[test]
@@ -157,6 +176,11 @@ fn chrome_assigns_semester_numbers() {
     let data = get_chrome_data();
     let courses = parse_copy_paste_data(&data).unwrap();
     for cs in &courses {
+        // 0-credit exemptions have no semester by design
+        if cs.course.credit == 0.0 && cs.grade == Some(Grade::ExemptionWithoutCredit) {
+            assert!(cs.semester.is_none(), "0-credit exemption course {} should have no semester", cs.course.id);
+            continue;
+        }
         assert!(
             cs.semester.is_some(),
             "Course {} has no semester",

--- a/packages/server/src/core/parser_v2_tests.rs
+++ b/packages/server/src/core/parser_v2_tests.rs
@@ -68,7 +68,7 @@ fn edge_uses_8_digit_course_ids() {
 }
 
 fn find_course<'a>(courses: &'a [CourseStatus], id: &str) -> Option<&'a CourseStatus> {
-    courses.iter().find(|cs| cs.course.id == id)
+    courses.iter().find(|cs| *cs.course.id == *id)
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn chrome_parses_sport_courses_with_duplicates() {
     assert!(sport.len() >= 4, "Expected at least 4 sport courses");
     let duplicates: Vec<_> = sport
         .iter()
-        .filter(|cs| cs.course.id == "03940803")
+        .filter(|cs| *cs.course.id == *"03940803")
         .collect();
     assert_eq!(duplicates.len(), 2, "Expected 2 instances of 03940803");
 }

--- a/packages/server/src/core/tests.rs
+++ b/packages/server/src/core/tests.rs
@@ -598,8 +598,9 @@ async fn run_degree_status(mut degree_status: DegreeStatus, catalog: Catalog) ->
         .get_all::<Course>()
         .await
         .expect("failed to get all courses");
-    degree_status.fill_tags(&vec_courses);
-    degree_status.compute(catalog, course::vec_to_map(vec_courses));
+    let courses = course::vec_to_map(vec_courses);
+    degree_status.fill_tags(&courses);
+    degree_status.compute(catalog, courses);
     degree_status
 }
 

--- a/packages/server/src/core/tests.rs
+++ b/packages/server/src/core/tests.rs
@@ -599,7 +599,6 @@ async fn run_degree_status(mut degree_status: DegreeStatus, catalog: Catalog) ->
         .await
         .expect("failed to get all courses");
     let courses = course::vec_to_map(vec_courses);
-    degree_status.fill_tags(&courses);
     degree_status.compute(catalog, courses);
     degree_status
 }

--- a/packages/server/src/core/tests.rs
+++ b/packages/server/src/core/tests.rs
@@ -8,7 +8,7 @@ use crate::db::Db;
 use crate::resources::catalog::Catalog;
 use crate::resources::course::CourseState::NotComplete;
 use crate::resources::course::Grade::Numeric;
-use crate::resources::course::{self, Course, CourseState, CourseStatus, Grade, Tag};
+use crate::resources::course::{self, Course, CourseId, CourseState, CourseStatus, Grade, Tag};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -62,7 +62,7 @@ async fn test_asterisk_course_input_from_edge_browser() {
 
     let course_status = courses_display_from_pdf
         .iter()
-        .find(|c| c.course.id == "094412")
+        .find(|c| *c.course.id == *"00940412")
         .unwrap();
 
     assert_eq!(course_status.grade.as_ref().unwrap(), &Grade::Numeric(92));
@@ -78,7 +78,7 @@ async fn test_asterisk_course_input_from_chrome_browser() {
 
     let course_status = courses_display_from_pdf
         .iter()
-        .find(|c| c.course.id == "234129")
+        .find(|c| *c.course.id == *"02340129")
         .unwrap();
 
     assert_eq!(course_status.grade.as_ref().unwrap(), &Grade::Numeric(67));
@@ -91,7 +91,10 @@ async fn test_parser_copy_paste_from_acrobat_reader() {
         .expect("Something went wrong reading the file");
 
     let courses = parser::parse_copy_paste_data(&from_pdf).unwrap();
-    let course_status = courses.iter().find(|c| c.course.id == "234325").unwrap();
+    let course_status = courses
+        .iter()
+        .find(|c| *c.course.id == *"02340325")
+        .unwrap();
 
     assert_eq!(course_status.course.credit, 3.0);
     assert_eq!(course_status.course.name, "גרפיקה ממוחשבת1");
@@ -101,7 +104,10 @@ async fn test_parser_copy_paste_from_acrobat_reader() {
         .expect("Something went wrong reading the file");
 
     let courses = parser::parse_copy_paste_data(&from_pdf).unwrap();
-    let course_status = courses.iter().find(|c| c.course.id == "274400").unwrap();
+    let course_status = courses
+        .iter()
+        .find(|c| *c.course.id == *"02740400")
+        .unwrap();
 
     assert_eq!(course_status.course.credit, 20.0);
     assert_eq!(
@@ -117,7 +123,10 @@ async fn test_parser_copy_paste_med_status() {
         .expect("Something went wrong reading the file");
 
     let courses = parser::parse_copy_paste_data(&from_pdf).unwrap();
-    let course_status = courses.iter().find(|c| c.course.id == "274400").unwrap();
+    let course_status = courses
+        .iter()
+        .find(|c| *c.course.id == *"02740400")
+        .unwrap();
 
     assert_eq!(course_status.course.credit, 20.0);
     assert_eq!(
@@ -133,9 +142,18 @@ async fn test_parser_course_status_repetitions() {
         .expect("Something went wrong reading the file");
 
     let courses = parser::parse_copy_paste_data(&from_pdf).unwrap();
-    let course_status = courses.iter().find(|c| c.course.id == "234247").unwrap();
-    let course_status2 = courses.iter().find(|c| c.course.id == "094591").unwrap();
-    let course_status3 = courses.iter().find(|c| c.course.id == "114052").unwrap();
+    let course_status = courses
+        .iter()
+        .find(|c| *c.course.id == *"02340247")
+        .unwrap();
+    let course_status2 = courses
+        .iter()
+        .find(|c| *c.course.id == *"00940591")
+        .unwrap();
+    let course_status3 = courses
+        .iter()
+        .find(|c| *c.course.id == *"01140052")
+        .unwrap();
 
     assert_eq!(course_status.times_repeated, 1);
     assert_eq!(course_status2.times_repeated, 1);
@@ -144,84 +162,84 @@ async fn test_parser_course_status_repetitions() {
     dbg!(course_status3);
 }
 
-static COURSES: LazyLock<HashMap<String, Course>> = LazyLock::new(|| {
+static COURSES: LazyLock<HashMap<CourseId, Course>> = LazyLock::new(|| {
     HashMap::from([
         (
-            "104031".to_string(),
+            CourseId::new("104031"),
             Course {
-                id: "104031".to_string(),
+                id: CourseId::new("104031"),
                 credit: 5.5,
                 name: "infi1m".to_string(),
                 tags: None,
             },
         ),
         (
-            "104166".to_string(),
+            CourseId::new("104166"),
             Course {
-                id: "104166".to_string(),
+                id: CourseId::new("104166"),
                 credit: 5.5,
                 name: "Algebra alef".to_string(),
                 tags: None,
             },
         ),
         (
-            "114052".to_string(),
+            CourseId::new("114052"),
             Course {
-                id: "114052".to_string(),
+                id: CourseId::new("114052"),
                 credit: 3.5,
                 name: "פיסיקה 2".to_string(),
                 tags: None,
             },
         ),
         (
-            "114054".to_string(),
+            CourseId::new("114054"),
             Course {
-                id: "114054".to_string(),
+                id: CourseId::new("114054"),
                 credit: 3.5,
                 name: "פיסיקה 3".to_string(),
                 tags: None,
             },
         ),
         (
-            "236303".to_string(),
+            CourseId::new("236303"),
             Course {
-                id: "236303".to_string(),
+                id: CourseId::new("236303"),
                 credit: 3.0,
                 name: "project1".to_string(),
                 tags: None,
             },
         ),
         (
-            "236512".to_string(),
+            CourseId::new("236512"),
             Course {
-                id: "236512".to_string(),
+                id: CourseId::new("236512"),
                 credit: 3.0,
                 name: "project2".to_string(),
                 tags: None,
             },
         ),
         (
-            "1".to_string(),
+            CourseId::new("1"),
             Course {
-                id: "1".to_string(),
+                id: CourseId::new("1"),
                 credit: 1.0,
                 name: "".to_string(),
                 tags: None,
             },
         ),
         (
-            "2".to_string(),
+            CourseId::new("2"),
             Course {
-                id: "2".to_string(),
+                id: CourseId::new("2"),
                 credit: 2.0,
                 name: "".to_string(),
                 tags: None,
             },
         ),
         (
-            "3".to_string(),
+            CourseId::new("3"),
             Course {
-                id: "3".to_string(),
+                id: CourseId::new("3"),
                 credit: 3.0,
                 name: "".to_string(),
                 tags: None,
@@ -249,7 +267,7 @@ pub fn create_degree_status() -> DegreeStatus {
         course_statuses: vec![
             CourseStatus {
                 course: Course {
-                    id: "104031".to_string(),
+                    id: CourseId::new("104031"),
                     credit: 5.5,
                     name: "infi1m".to_string(),
                     tags: None,
@@ -260,7 +278,7 @@ pub fn create_degree_status() -> DegreeStatus {
             },
             CourseStatus {
                 course: Course {
-                    id: "104166".to_string(),
+                    id: CourseId::new("104166"),
                     credit: 5.5,
                     name: "Algebra alef".to_string(),
                     tags: None,
@@ -271,7 +289,7 @@ pub fn create_degree_status() -> DegreeStatus {
             },
             CourseStatus {
                 course: Course {
-                    id: "114052".to_string(),
+                    id: CourseId::new("114052"),
                     credit: 3.5,
                     name: "פיסיקה 2".to_string(),
                     tags: None,
@@ -282,7 +300,7 @@ pub fn create_degree_status() -> DegreeStatus {
             },
             CourseStatus {
                 course: Course {
-                    id: "114054".to_string(),
+                    id: CourseId::new("114054"),
                     credit: 3.5,
                     name: "פיסיקה 3".to_string(),
                     tags: None,
@@ -293,7 +311,7 @@ pub fn create_degree_status() -> DegreeStatus {
             },
             CourseStatus {
                 course: Course {
-                    id: "236303".to_string(),
+                    id: CourseId::new("236303"),
                     credit: 3.0,
                     name: "project1".to_string(),
                     tags: None,
@@ -304,7 +322,7 @@ pub fn create_degree_status() -> DegreeStatus {
             },
             CourseStatus {
                 course: Course {
-                    id: "236512".to_string(),
+                    id: CourseId::new("236512"),
                     credit: 3.0,
                     name: "project2".to_string(),
                     tags: None,
@@ -315,7 +333,7 @@ pub fn create_degree_status() -> DegreeStatus {
             },
             CourseStatus {
                 course: Course {
-                    id: "324057".to_string(),
+                    id: CourseId::new("324057"),
                     credit: 2.0,
                     name: "mlg".to_string(),
                     tags: Some(vec![Tag::Malag]),
@@ -326,7 +344,7 @@ pub fn create_degree_status() -> DegreeStatus {
             },
             CourseStatus {
                 course: Course {
-                    id: "394645".to_string(), // Sport
+                    id: CourseId::new("394645"), // Sport
                     credit: 1.0,
                     name: "sport".to_string(),
                     tags: Some(vec![Tag::Sport]),
@@ -348,7 +366,7 @@ async fn test_irrelevant_course() {
     let mut degree_status = create_degree_status();
     degree_status.course_statuses[2].state = Some(CourseState::Irrelevant); // change 114052 to be irrelevant
     let bank_name = "hova".to_string();
-    let course_list = vec!["104031".to_string(), "114052".to_string()];
+    let course_list = vec![CourseId::new("104031"), CourseId::new("114052")];
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 0.0, 0);
     let mut missing_credit_dummy = 0.0;
@@ -367,7 +385,7 @@ async fn test_restore_irrelevant_course() {
     .await;
 
     for course_status in degree_status.course_statuses.iter_mut() {
-        if course_status.course.id == "114071" {
+        if *course_status.course.id == *"01140071" {
             // tag פיסיקה1מ as irrelevant
             course_status.state = Some(CourseState::Irrelevant);
         }
@@ -380,7 +398,7 @@ async fn test_restore_irrelevant_course() {
     .await;
     degree_status.course_statuses.push(CourseStatus {
         course: Course {
-            id: "114071".to_string(),
+            id: CourseId::new("114071"),
             credit: 2.5,
             name: "פיסיקה 1מ".to_string(),
             tags: None,
@@ -411,7 +429,7 @@ async fn test_modified() {
     degree_status.course_statuses[0].r#type = Some("reshima alef".to_string()); // the user modified the type of 104031 to be reshima alef
     degree_status.course_statuses[0].modified = true;
     let bank_name = "hova".to_string();
-    let course_list = vec!["104031".to_string(), "104166".to_string()]; // although 104031 is in the list, it shouldn't be taken because the user modified its type
+    let course_list = vec![CourseId::new("104031"), CourseId::new("104166")]; // although 104031 is in the list, it shouldn't be taken because the user modified its type
     let handle_bank_rule_processor =
         create_bank_rule_handler!(&mut degree_status, bank_name, course_list, 0.0, 0);
     let mut missing_credit_dummy = 0.0;
@@ -448,7 +466,7 @@ async fn test_modified() {
     degree_status.course_statuses[3].r#type = Some("reshima alef".to_string()); // the user modified the type of 114054 to be reshima alef
     degree_status.course_statuses[3].modified = true;
     let bank_name = "hova".to_string();
-    let course_list = vec!["104031".to_string(), "104166".to_string()]; // although 114052 is not in the list, it should be taken because the user modified its type
+    let course_list = vec![CourseId::new("104031"), CourseId::new("104166")]; // although 114052 is not in the list, it should be taken because the user modified its type
 
     let handle_bank_rule_processor = create_bank_rule_handler!(
         &mut degree_status,
@@ -498,7 +516,7 @@ async fn test_duplicated_courses() {
     // This code Simulates addition of פיסיקה 1 manually by the user.
     degree_status.course_statuses.push(CourseStatus {
         course: Course {
-            id: "114051".to_string(),
+            id: CourseId::new("114051"),
             credit: 2.5,
             name: "פיסיקה 1".to_string(),
             tags: None,
@@ -531,7 +549,7 @@ async fn test_course_replacement() {
     let mut degree_status = DegreeStatus {
         course_statuses: vec![CourseStatus {
             course: Course {
-                id: "104195".to_string(),
+                id: CourseId::new("104195"),
                 credit: 5.5,
                 name: "אינפי 1".to_string(),
                 tags: None,
@@ -550,11 +568,11 @@ async fn test_course_replacement() {
 
     assert_eq!(
         degree_status
-            .get_course_status("104195")
+            .get_course_status(&CourseId::new("104195"))
             .unwrap()
             .additional_msg,
         Some(messages::common_replacement_msg(&Course {
-            id: "104031".to_string(),
+            id: CourseId::new("104031"),
             credit: 5.5,
             name: "חשבון אינפיניטסימלי 1מ'".to_string(),
             tags: None,
@@ -733,7 +751,7 @@ async fn test_computer_engineer_itinerary() {
     // Replacement for 236334 that is part of "רשימות ליבה" and "קבוצות התמחות"
     degree_status.course_statuses.push(CourseStatus {
         course: Course {
-            id: "044334".to_string(),
+            id: CourseId::new("044334"),
             credit: 3.0,
             name: "רשתות מחשבים ואינטרנט 1".to_string(),
             tags: None,
@@ -748,7 +766,7 @@ async fn test_computer_engineer_itinerary() {
     // Replacement for 236341 that is part of "קבוצות התמחות"
     degree_status.course_statuses.push(CourseStatus {
         course: Course {
-            id: "046005".to_string(),
+            id: CourseId::new("046005"),
             credit: 3.0,
             name: "רשתות מחשבים ואינטרנט 2".to_string(),
             tags: None,
@@ -763,7 +781,7 @@ async fn test_computer_engineer_itinerary() {
     // This course is part of "קבוצות התמחות" in the catalog
     degree_status.course_statuses.push(CourseStatus {
         course: Course {
-            id: "236357".to_string(),
+            id: CourseId::new("236357"),
             credit: 3.0,
             name: "אלגוריתמים מובזרים א'".to_string(),
             tags: None,
@@ -918,7 +936,9 @@ async fn test_postprocessing_english_requirement() {
     degree_status
         .course_statuses
         .iter_mut()
-        .find(|course_status| course_status.course.id == consts::TECHNICAL_ENGLISH_ADVANCED_B)
+        .find(|course_status| {
+            course_status.course.id == CourseId::new(consts::TECHNICAL_ENGLISH_ADVANCED_B_ID)
+        })
         .unwrap()
         .grade = Some(Grade::Numeric(80));
 
@@ -937,7 +957,9 @@ async fn test_postprocessing_english_requirement() {
     degree_status
         .course_statuses
         .iter_mut()
-        .find(|course_status| course_status.course.id == consts::TECHNICAL_ENGLISH_ADVANCED_B)
+        .find(|course_status| {
+            course_status.course.id == CourseId::new(consts::TECHNICAL_ENGLISH_ADVANCED_B_ID)
+        })
         .unwrap()
         .state = Some(CourseState::NotComplete);
 
@@ -962,8 +984,12 @@ async fn test_postprocessing_medicine_requirement() {
     // )
     // .expect("Unable to write file");
 
-    let cs1 = degree_status.get_course_status("274109").unwrap();
-    let cs2 = degree_status.get_course_status("274143").unwrap();
+    let cs1 = degree_status
+        .get_course_status(&CourseId::new("274109"))
+        .unwrap();
+    let cs2 = degree_status
+        .get_course_status(&CourseId::new("274143"))
+        .unwrap();
 
     // The student repeated a mandatory course 274109 twice
     assert!(
@@ -1008,7 +1034,7 @@ async fn test_postprocessing_medicine_requirement() {
     degree_status.course_statuses.push(CourseStatus {
         course: Course {
             credit: 1.0,
-            id: "275101".to_string(),
+            id: CourseId::new("275101"),
             name: "".to_string(),
             tags: None,
         },

--- a/packages/server/src/core/types.rs
+++ b/packages/server/src/core/types.rs
@@ -41,6 +41,12 @@ pub enum Rule {
     Wildcard(bool), // קלף משוגע עבור להתמודד עם
 }
 
+impl Rule {
+    pub fn is_accumulate(&self) -> bool {
+        matches!(self, Rule::AccumulateCredit | Rule::AccumulateCourses(_))
+    }
+}
+
 impl fmt::Display for Rule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {

--- a/packages/server/src/db/tests.rs
+++ b/packages/server/src/db/tests.rs
@@ -94,7 +94,7 @@ pub async fn test_get_courses_by_filters() {
         .expect("Failed to get courses by name");
 
     assert_eq!(courses.len(), 2); // Since 2024 there are 2 formats for the course id: 6 digit and 8 digit
-    // Both are normalized to 8-digit by CourseId deserialization
+                                  // Both are normalized to 8-digit by CourseId deserialization
     assert!(courses
         .iter()
         .all(|c| *c.id == *"01040031" && c.name == "חשבון אינפיניטסימלי 1מ'"));
@@ -118,10 +118,7 @@ pub async fn test_get_courses_by_filters() {
         .expect("Failed to get courses by number");
 
     assert_eq!(courses.len(), 3);
-    assert!(courses
-        .iter()
-        .filter(|c| *c.id == *"01040031")
-        .count() == 2); // both 6-digit and 8-digit normalize to same id
+    assert!(courses.iter().filter(|c| *c.id == *"01040031").count() == 2); // both 6-digit and 8-digit normalize to same id
     assert!(courses
         .iter()
         .any(|c| *c.id == *"01040166" && c.name == "אלגברה אמ'"));

--- a/packages/server/src/db/tests.rs
+++ b/packages/server/src/db/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{Db, FilterOption},
-    resources::course::Course,
+    resources::course::{Course, CourseId},
 };
 use axum::{http::StatusCode, response::IntoResponse};
 
@@ -45,13 +45,13 @@ pub async fn test_db_internal_error() {
             .expect_err("Expected error"),
         db.get_all::<Course>().await.expect_err("Expected error"),
         db.create_or_update::<Course>(Course {
-            id: "124400".into(),
+            id: CourseId::new("124400"),
             ..Default::default()
         })
         .await
         .expect_err("Expected error"),
         db.update::<Course>(Course {
-            id: "124400".into(),
+            id: CourseId::new("124400"),
             ..Default::default()
         })
         .await
@@ -94,12 +94,10 @@ pub async fn test_get_courses_by_filters() {
         .expect("Failed to get courses by name");
 
     assert_eq!(courses.len(), 2); // Since 2024 there are 2 formats for the course id: 6 digit and 8 digit
+    // Both are normalized to 8-digit by CourseId deserialization
     assert!(courses
         .iter()
-        .any(|c| c.id == "104031" && c.name == "חשבון אינפיניטסימלי 1מ'"));
-    assert!(courses
-        .iter()
-        .any(|c| c.id == "01040031" && c.name == "חשבון אינפיניטסימלי 1מ'"));
+        .all(|c| *c.id == *"01040031" && c.name == "חשבון אינפיניטסימלי 1מ'"));
 
     let courses = db
         .get_filtered::<Course>(FilterOption::Regex, "_id", "104031")
@@ -108,7 +106,7 @@ pub async fn test_get_courses_by_filters() {
 
     assert_eq!(courses.len(), 1);
     assert_eq!(courses[0].name, "חשבון אינפיניטסימלי 1מ'");
-    assert_eq!(courses[0].id, "104031");
+    assert_eq!(*courses[0].id, *"01040031"); // normalized from "104031"
 
     let courses = db
         .get_filtered::<Course>(
@@ -122,11 +120,9 @@ pub async fn test_get_courses_by_filters() {
     assert_eq!(courses.len(), 3);
     assert!(courses
         .iter()
-        .any(|c| c.id == "104031" && c.name == "חשבון אינפיניטסימלי 1מ'"));
+        .filter(|c| *c.id == *"01040031")
+        .count() == 2); // both 6-digit and 8-digit normalize to same id
     assert!(courses
         .iter()
-        .any(|c| c.id == "01040031" && c.name == "חשבון אינפיניטסימלי 1מ'"));
-    assert!(courses
-        .iter()
-        .any(|c| c.id == "104166" && c.name == "אלגברה אמ'"));
+        .any(|c| *c.id == *"01040166" && c.name == "אלגברה אמ'"));
 }

--- a/packages/server/src/disk_cache.rs
+++ b/packages/server/src/disk_cache.rs
@@ -7,6 +7,7 @@
 //!   {cache_dir}/{year}/{semester}/_index.json
 //!   {cache_dir}/{year}/{semester}/{course_id}.json
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -14,7 +15,9 @@ use std::time::Duration;
 
 use moka::future::Cache;
 use serde::Serialize;
+use tokio::sync::RwLock;
 
+use sogrim_server::resources::course::{Course, CourseId};
 use sogrim_server::sap::{CourseDetails, CourseIndexEntry};
 
 const CACHE_TTL_HOURS: u64 = 6;
@@ -33,6 +36,9 @@ pub struct DiskCourseCache {
     cache_dir: PathBuf,
     courses: Cache<String, Arc<CourseDetails>>,
     indexes: Cache<String, Arc<Vec<CourseIndexEntry>>>,
+    /// Flat deduplicated course list built from all semesters.
+    /// Most recent semester takes precedence for each course id.
+    all_courses: RwLock<HashMap<CourseId, Course>>,
 }
 
 impl DiskCourseCache {
@@ -45,6 +51,7 @@ impl DiskCourseCache {
                 .max_capacity(20_000)
                 .build(),
             indexes: Cache::builder().time_to_live(ttl).max_capacity(20).build(),
+            all_courses: RwLock::new(HashMap::new()),
         }
     }
 
@@ -142,7 +149,9 @@ impl DiskCourseCache {
     pub async fn load_all(&self) {
         let semesters = self.discover_semesters();
         let mut total = 0usize;
-        for sem in &semesters {
+        // Build the flat course map: iterate oldest-first so newer semesters overwrite
+        let mut flat_courses: HashMap<CourseId, Course> = HashMap::new();
+        for sem in semesters.iter().rev() {
             let sem_dir = self.cache_dir.join(&sem.year).join(&sem.semester);
             let Ok(entries) = fs::read_dir(&sem_dir) else {
                 continue;
@@ -156,6 +165,7 @@ impl DiskCourseCache {
                 let key = format!("{}/{}/{}", sem.year, sem.semester, course_id);
                 if let Ok(data) = fs::read_to_string(entry.path()) {
                     if let Ok(details) = serde_json::from_str::<CourseDetails>(&data) {
+                        flat_courses.insert(details.id.clone(), Course::from(&details));
                         self.courses.insert(key, Arc::new(details)).await;
                         total += 1;
                     }
@@ -164,12 +174,19 @@ impl DiskCourseCache {
             // Also load the index
             let _ = self.get_index(&sem.year, &sem.semester).await;
         }
+        *self.all_courses.write().await = flat_courses;
         log::info!(
             target: "sogrim_server",
-            "Loaded {} courses from {} semesters into memory",
+            "Loaded {} courses from {} semesters into memory ({} unique courses in flat list)",
             total,
-            semesters.len()
+            semesters.len(),
+            self.all_courses.read().await.len(),
         );
+    }
+
+    /// Return all courses from the flat deduplicated list as a map keyed by course ID.
+    pub async fn get_all_courses(&self) -> HashMap<CourseId, Course> {
+        self.all_courses.read().await.clone()
     }
 }
 

--- a/packages/server/src/disk_cache.rs
+++ b/packages/server/src/disk_cache.rs
@@ -188,6 +188,21 @@ impl DiskCourseCache {
     pub async fn get_all_courses(&self) -> HashMap<CourseId, Course> {
         self.all_courses.read().await.clone()
     }
+
+    /// Create a cache pre-populated with the given courses (for tests only).
+    #[cfg(test)]
+    pub fn with_courses(courses: HashMap<CourseId, Course>) -> Self {
+        let ttl = Duration::from_secs(CACHE_TTL_HOURS * 3600);
+        Self {
+            cache_dir: PathBuf::new(),
+            courses: Cache::builder()
+                .time_to_live(ttl)
+                .max_capacity(20_000)
+                .build(),
+            indexes: Cache::builder().time_to_live(ttl).max_capacity(20).build(),
+            all_courses: RwLock::new(courses),
+        }
+    }
 }
 
 fn semester_display_name(year: &str, semester: &str) -> String {

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -9,8 +9,7 @@ use serde::{self, Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
-static YEAR_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?P<year>\d{4})").unwrap());
+static YEAR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?P<year>\d{4})").unwrap());
 static TRACK_NAME_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\s*\d{4}(-\d{4})?\s*").unwrap());
 
@@ -132,10 +131,7 @@ impl Catalog {
     /// Returns the track name by stripping the year portion from a catalog name string.
     /// E.g. "מדמח תלת שנתי 2022-2023" → "מדמח תלת שנתי"
     pub fn track_name_from_str(name: &str) -> String {
-        TRACK_NAME_RE
-            .replace_all(name, "")
-            .trim()
-            .to_string()
+        TRACK_NAME_RE.replace_all(name, "").trim().to_string()
     }
 
     pub fn track_name(&self) -> String {

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -7,6 +7,12 @@ use bson::{doc, Document};
 use regex::Regex;
 use serde::{self, Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+static YEAR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?P<year>\d{4})").unwrap());
+static TRACK_NAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\s*\d{4}(-\d{4})?\s*").unwrap());
 
 use super::course::{CourseId, CourseStatus};
 
@@ -57,8 +63,7 @@ impl Catalog {
 
     pub fn year(&self) -> usize {
         let default_year = 2018;
-        Regex::new(r"(?P<year>\d{4})")
-            .unwrap()
+        YEAR_RE
             .captures(&self.name)
             .map(|cap| cap["year"].parse::<usize>().unwrap_or(default_year))
             .unwrap_or(default_year)
@@ -127,8 +132,7 @@ impl Catalog {
     /// Returns the track name by stripping the year portion from a catalog name string.
     /// E.g. "מדמח תלת שנתי 2022-2023" → "מדמח תלת שנתי"
     pub fn track_name_from_str(name: &str) -> String {
-        Regex::new(r"\s*\d{4}(-\d{4})?\s*")
-            .unwrap()
+        TRACK_NAME_RE
             .replace_all(name, "")
             .trim()
             .to_string()

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -199,7 +199,10 @@ impl Catalog {
             if self.course_to_bank.contains_key(course_id) {
                 continue;
             }
-            if prefixes.iter().any(|prefix| course_id.starts_with(prefix.as_str())) {
+            if prefixes
+                .iter()
+                .any(|prefix| course_id.starts_with(prefix.as_str()))
+            {
                 self.course_to_bank
                     .insert(course_id.clone(), default_bank.clone());
             }

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use serde::{self, Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
-use super::course::CourseId;
+use super::course::{CourseId, CourseStatus};
 
 pub(crate) type OptionalReplacements = Vec<CourseId>;
 
@@ -37,7 +37,24 @@ pub struct Catalog {
     pub common_replacements: HashMap<CourseId, OptionalReplacements>, // Common replacement which usually approved by the coordinators
 }
 
+impl Faculty {
+    /// Returns the known course ID prefixes for this faculty.
+    /// Can be extended per-faculty as needed.
+    fn course_prefixes(&self) -> Vec<&str> {
+        match self {
+            Faculty::ComputerScience => vec!["0234", "0236"],
+            _ => vec![],
+        }
+    }
+}
+
 impl Catalog {
+    /// Returns course ID prefixes for this catalog, currently based on faculty.
+    /// Can be extended in the future to also consider the track name.
+    pub fn course_prefixes(&self) -> Vec<&str> {
+        self.faculty.course_prefixes()
+    }
+
     pub fn year(&self) -> usize {
         let default_year = 2018;
         Regex::new(r"(?P<year>\d{4})")
@@ -71,6 +88,27 @@ impl Catalog {
 
     pub fn is_medicine(&self) -> bool {
         matches!(self.faculty, Faculty::Medicine)
+    }
+
+    /// Returns the name of the accumulate bank with the most courses in `course_to_bank`.
+    /// Used to determine where prefix-matched, non-catalog courses should be counted.
+    pub fn default_accumulate_bank(&self) -> Option<String> {
+        let accumulate_bank_names: Vec<&str> = self
+            .course_banks
+            .iter()
+            .filter(|bank| bank.rule.is_accumulate())
+            .map(|bank| bank.name.as_str())
+            .collect();
+
+        accumulate_bank_names
+            .iter()
+            .max_by_key(|&&bank_name| {
+                self.course_to_bank
+                    .values()
+                    .filter(|v| v.as_str() == bank_name)
+                    .count()
+            })
+            .map(|&name| name.to_string())
     }
 
     // Iterate over all banks and replace the course with the replacement
@@ -139,6 +177,31 @@ impl Catalog {
                 }
                 self.course_to_bank
                     .insert(course_id.clone(), sibling_bank_name.clone());
+            }
+        }
+    }
+
+    /// Enrich this catalog with student courses that match the faculty's course prefixes
+    /// but are not already in `course_to_bank`. These courses are assigned to the
+    /// accumulate bank with the most courses (the "default" accumulate bank).
+    pub fn enrich_with_prefix_courses(&mut self, student_courses: &[CourseStatus]) {
+        let prefixes = self.course_prefixes();
+        if prefixes.is_empty() {
+            return;
+        }
+        let prefixes: Vec<String> = prefixes.into_iter().map(String::from).collect();
+        let Some(default_bank) = self.default_accumulate_bank() else {
+            return;
+        };
+
+        for course_status in student_courses {
+            let course_id = &course_status.course.id;
+            if self.course_to_bank.contains_key(course_id) {
+                continue;
+            }
+            if prefixes.iter().any(|prefix| course_id.starts_with(prefix.as_str())) {
+                self.course_to_bank
+                    .insert(course_id.clone(), default_bank.clone());
             }
         }
     }

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -1,7 +1,10 @@
 use crate::{
-    core::{credit_transfer_graph::find_traversal_order, types::CreditOverflow},
+    core::{
+        credit_transfer_graph::find_traversal_order,
+        types::{CreditOverflow, Rule},
+    },
     db::Resource,
-    resources::course::CourseBank,
+    resources::course::{to_8digit, CourseBank},
 };
 use bson::{doc, Document};
 use regex::Regex;
@@ -83,6 +86,65 @@ impl Catalog {
 
         for bank in self.course_banks.iter_mut() {
             bank.replace_course(course.clone(), replacement.clone());
+        }
+    }
+
+    /// Normalize all 6-digit course IDs in the catalog to 8-digit format.
+    pub fn normalize_course_ids(&mut self) {
+        fn normalize_id(id: &mut CourseId) {
+            if id.len() == 6 {
+                *id = to_8digit(id);
+            }
+        }
+
+        fn normalize_replacements_map(map: &mut HashMap<CourseId, OptionalReplacements>) {
+            let entries: Vec<_> = map.drain().collect();
+            for (mut key, mut values) in entries {
+                normalize_id(&mut key);
+                for v in values.iter_mut() {
+                    normalize_id(v);
+                }
+                map.insert(key, values);
+            }
+        }
+
+        // course_to_bank keys
+        let entries: Vec<_> = self.course_to_bank.drain().collect();
+        for (mut key, value) in entries {
+            normalize_id(&mut key);
+            self.course_to_bank.insert(key, value);
+        }
+
+        // catalog_replacements and common_replacements (keys + values)
+        normalize_replacements_map(&mut self.catalog_replacements);
+        normalize_replacements_map(&mut self.common_replacements);
+
+        // course_banks rules
+        for bank in self.course_banks.iter_mut() {
+            match &mut bank.rule {
+                Rule::Chains(chains) => {
+                    for chain in chains.iter_mut() {
+                        for id in chain.iter_mut() {
+                            normalize_id(id);
+                        }
+                    }
+                }
+                Rule::SpecializationGroups(groups) => {
+                    for group in groups.groups_list.iter_mut() {
+                        for id in group.course_list.iter_mut() {
+                            normalize_id(id);
+                        }
+                        if let Some(mandatory) = &mut group.mandatory {
+                            for replacements in mandatory.iter_mut() {
+                                for id in replacements.iter_mut() {
+                                    normalize_id(id);
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
     }
 }

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -1,10 +1,10 @@
 use crate::{
     core::{
         credit_transfer_graph::find_traversal_order,
-        types::{CreditOverflow, Rule},
+        types::CreditOverflow,
     },
     db::Resource,
-    resources::course::{to_8digit, CourseBank},
+    resources::course::CourseBank,
 };
 use bson::{doc, Document};
 use regex::Regex;
@@ -54,7 +54,7 @@ impl Catalog {
         let mut course_list_for_bank = Vec::new();
         for (course_id, bank_name) in &self.course_to_bank {
             if *bank_name == name {
-                course_list_for_bank.push(course_id.to_string());
+                course_list_for_bank.push(course_id.clone());
             }
         }
         course_list_for_bank
@@ -86,65 +86,6 @@ impl Catalog {
 
         for bank in self.course_banks.iter_mut() {
             bank.replace_course(course.clone(), replacement.clone());
-        }
-    }
-
-    /// Normalize all 6-digit course IDs in the catalog to 8-digit format.
-    pub fn normalize_course_ids(&mut self) {
-        fn normalize_id(id: &mut CourseId) {
-            if id.len() == 6 {
-                *id = to_8digit(id);
-            }
-        }
-
-        fn normalize_replacements_map(map: &mut HashMap<CourseId, OptionalReplacements>) {
-            let entries: Vec<_> = map.drain().collect();
-            for (mut key, mut values) in entries {
-                normalize_id(&mut key);
-                for v in values.iter_mut() {
-                    normalize_id(v);
-                }
-                map.insert(key, values);
-            }
-        }
-
-        // course_to_bank keys
-        let entries: Vec<_> = self.course_to_bank.drain().collect();
-        for (mut key, value) in entries {
-            normalize_id(&mut key);
-            self.course_to_bank.insert(key, value);
-        }
-
-        // catalog_replacements and common_replacements (keys + values)
-        normalize_replacements_map(&mut self.catalog_replacements);
-        normalize_replacements_map(&mut self.common_replacements);
-
-        // course_banks rules
-        for bank in self.course_banks.iter_mut() {
-            match &mut bank.rule {
-                Rule::Chains(chains) => {
-                    for chain in chains.iter_mut() {
-                        for id in chain.iter_mut() {
-                            normalize_id(id);
-                        }
-                    }
-                }
-                Rule::SpecializationGroups(groups) => {
-                    for group in groups.groups_list.iter_mut() {
-                        for id in group.course_list.iter_mut() {
-                            normalize_id(id);
-                        }
-                        if let Some(mandatory) = &mut group.mandatory {
-                            for replacements in mandatory.iter_mut() {
-                                for id in replacements.iter_mut() {
-                                    normalize_id(id);
-                                }
-                            }
-                        }
-                    }
-                }
-                _ => {}
-            }
         }
     }
 }

--- a/packages/server/src/resources/catalog.rs
+++ b/packages/server/src/resources/catalog.rs
@@ -1,15 +1,12 @@
 use crate::{
-    core::{
-        credit_transfer_graph::find_traversal_order,
-        types::CreditOverflow,
-    },
+    core::{credit_transfer_graph::find_traversal_order, types::CreditOverflow},
     db::Resource,
     resources::course::CourseBank,
 };
 use bson::{doc, Document};
 use regex::Regex;
 use serde::{self, Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::course::CourseId;
 
@@ -86,6 +83,63 @@ impl Catalog {
 
         for bank in self.course_banks.iter_mut() {
             bank.replace_course(course.clone(), replacement.clone());
+        }
+    }
+
+    /// Returns the track name by stripping the year portion from a catalog name string.
+    /// E.g. "מדמח תלת שנתי 2022-2023" → "מדמח תלת שנתי"
+    pub fn track_name_from_str(name: &str) -> String {
+        Regex::new(r"\s*\d{4}(-\d{4})?\s*")
+            .unwrap()
+            .replace_all(name, "")
+            .trim()
+            .to_string()
+    }
+
+    pub fn track_name(&self) -> String {
+        Self::track_name_from_str(&self.name)
+    }
+
+    /// Enrich this catalog with courses from sibling catalogs (same track, different years).
+    /// Only courses from AccumulateCredit and AccumulateCourses banks are merged.
+    /// The current catalog always takes priority — existing course_to_bank entries are never overridden.
+    pub fn enrich_with_sibling_courses(&mut self, siblings: &[Catalog]) {
+        let accumulate_bank_names: HashSet<&str> = self
+            .course_banks
+            .iter()
+            .filter(|bank| bank.rule.is_accumulate())
+            .map(|bank| bank.name.as_str())
+            .collect();
+
+        for sibling in siblings {
+            if sibling.id == self.id {
+                // Skip current catalog
+                continue;
+            }
+
+            let sibling_accumulate_banks: HashSet<&str> = sibling
+                .course_banks
+                .iter()
+                .filter(|bank| bank.rule.is_accumulate())
+                .map(|bank| bank.name.as_str())
+                .collect();
+
+            for (course_id, sibling_bank_name) in &sibling.course_to_bank {
+                // Current catalog always takes priority
+                if self.course_to_bank.contains_key(course_id) {
+                    continue;
+                }
+                // Only merge from accumulate-type banks in the sibling
+                if !sibling_accumulate_banks.contains(sibling_bank_name.as_str()) {
+                    continue;
+                }
+                // Only merge if we have a matching accumulate bank with this name
+                if !accumulate_bank_names.contains(sibling_bank_name.as_str()) {
+                    continue;
+                }
+                self.course_to_bank
+                    .insert(course_id.clone(), sibling_bank_name.clone());
+            }
         }
     }
 }

--- a/packages/server/src/resources/course.rs
+++ b/packages/server/src/resources/course.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 
 use crate::core::types::Rule;
 use crate::db::Resource;
+use crate::sap::CourseDetails;
 
 const NON_STANDARD_PREFIXES: [&str; 4] = ["51", "52", "61", "97"];
 
@@ -108,6 +109,27 @@ pub enum Tag {
     SportTeam, // TODO: check if need this
     MedicinePreclinical,
     MedicineClinical,
+}
+
+impl From<&CourseDetails> for Course {
+    fn from(details: &CourseDetails) -> Self {
+        let mut tags = Vec::new();
+        if details.is_english {
+            tags.push(Tag::English);
+        }
+        if details.is_sport {
+            tags.push(Tag::Sport);
+        }
+        if details.is_malag {
+            tags.push(Tag::Malag);
+        }
+        Course {
+            id: details.id.clone(),
+            credit: details.credits,
+            name: details.name.clone(),
+            tags: if tags.is_empty() { None } else { Some(tags) },
+        }
+    }
 }
 
 impl Course {

--- a/packages/server/src/resources/course.rs
+++ b/packages/server/src/resources/course.rs
@@ -10,6 +10,19 @@ use crate::db::Resource;
 
 pub type CourseId = String;
 
+const NON_STANDARD_PREFIXES: [&str; 4] = ["51", "52", "61", "97"];
+
+/// Convert a 6-digit course ID to its canonical 8-digit format.
+/// Standard (most courses):     ABCDEF → 0ABC0DEF
+/// Non-standard (faculties 51, 52, 61, 97): ABCDEF → AB0C0DEF
+pub fn to_8digit(id: &str) -> String {
+    if NON_STANDARD_PREFIXES.iter().any(|p| id.starts_with(p)) {
+        format!("{}0{}0{}", &id[..2], &id[2..3], &id[3..])
+    } else {
+        format!("0{}0{}", &id[..3], &id[3..])
+    }
+}
+
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct Course {
     #[serde(rename(serialize = "_id", deserialize = "_id"))]

--- a/packages/server/src/resources/course.rs
+++ b/packages/server/src/resources/course.rs
@@ -1,25 +1,83 @@
 use bson::{doc, Document};
 use serde::de::{Error as Err, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::fmt;
 use std::iter::FromIterator;
+use std::ops::Deref;
 
 use crate::core::types::Rule;
 use crate::db::Resource;
 
-pub type CourseId = String;
-
 const NON_STANDARD_PREFIXES: [&str; 4] = ["51", "52", "61", "97"];
 
-/// Convert a 6-digit course ID to its canonical 8-digit format.
-/// Standard (most courses):     ABCDEF → 0ABC0DEF
-/// Non-standard (faculties 51, 52, 61, 97): ABCDEF → AB0C0DEF
-pub fn to_8digit(id: &str) -> String {
-    if NON_STANDARD_PREFIXES.iter().any(|p| id.starts_with(p)) {
-        format!("{}0{}0{}", &id[..2], &id[2..3], &id[3..])
-    } else {
-        format!("0{}0{}", &id[..3], &id[3..])
+/// A normalized course identifier.
+///
+/// The constructor automatically converts 6-digit IDs to the canonical 8-digit
+/// format, so all downstream code can assume IDs are always 8-digit.
+#[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct CourseId {
+    id: String,
+}
+
+impl<'de> Deserialize<'de> for CourseId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Ok(CourseId::new(raw))
+    }
+}
+
+impl CourseId {
+    pub fn new(raw: impl Into<String>) -> Self {
+        let raw: String = raw.into();
+        let id = if raw.len() == 6 {
+            Self::to_8digit(&raw)
+        } else {
+            raw
+        };
+        CourseId { id }
+    }
+
+    /// Convert a 6-digit course ID to its canonical 8-digit format.
+    /// Standard (most courses):     ABCDEF → 0ABC0DEF
+    /// Non-standard (faculties 51, 52, 61, 97): ABCDEF → AB0C0DEF
+    fn to_8digit(id: &str) -> String {
+        if NON_STANDARD_PREFIXES.iter().any(|p| id.starts_with(p)) {
+            format!("{}0{}0{}", &id[..2], &id[2..3], &id[3..])
+        } else {
+            format!("0{}0{}", &id[..3], &id[3..])
+        }
+    }
+}
+
+impl Deref for CourseId {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.id
+    }
+}
+
+impl fmt::Display for CourseId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.id)
+    }
+}
+
+impl From<CourseId> for bson::Bson {
+    fn from(id: CourseId) -> bson::Bson {
+        bson::Bson::String(id.id)
+    }
+}
+
+impl Borrow<str> for CourseId {
+    fn borrow(&self) -> &str {
+        &self.id
     }
 }
 
@@ -38,7 +96,7 @@ impl Resource for Course {
         "Courses"
     }
     fn key(&self) -> Document {
-        doc! {"_id": self.id.clone()}
+        doc! {"_id": self.id.to_string()}
     }
 }
 

--- a/packages/server/src/resources/tests.rs
+++ b/packages/server/src/resources/tests.rs
@@ -1,6 +1,8 @@
 use serde_json::json;
 
-use super::course::{CourseState, Grade};
+use super::catalog::Catalog;
+use super::course::{CourseBank, CourseId, CourseState, Grade};
+use crate::core::types::Rule;
 
 #[tokio::test]
 async fn test_course_state_serde() {
@@ -52,4 +54,222 @@ async fn test_course_grade_serde() {
     let res: Result<Grade, _> = serde_json::from_value(json!("-"));
     assert!(res.is_err());
     assert!(format!("{res:#?}").contains("expected a valid string representation of a grade"));
+}
+
+fn make_catalog(name: &str, banks: Vec<(&str, Rule)>, courses: Vec<(&str, &str)>) -> Catalog {
+    Catalog {
+        name: name.to_string(),
+        course_banks: banks
+            .into_iter()
+            .map(|(bank_name, rule)| CourseBank {
+                name: bank_name.to_string(),
+                rule,
+                credit: Some(10.0),
+            })
+            .collect(),
+        course_to_bank: courses
+            .into_iter()
+            .map(|(course_id, bank)| (CourseId::new(course_id), bank.to_string()))
+            .collect(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_track_name_strips_single_year() {
+    let catalog = Catalog {
+        name: "מדמח תלת שנתי 2022".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(catalog.track_name(), "מדמח תלת שנתי");
+}
+
+#[test]
+fn test_track_name_strips_year_range() {
+    let catalog = Catalog {
+        name: "מדמח תלת שנתי 2022-2023".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(catalog.track_name(), "מדמח תלת שנתי");
+}
+
+#[test]
+fn test_track_name_no_year() {
+    let catalog = Catalog {
+        name: "מדמח תלת שנתי".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(catalog.track_name(), "מדמח תלת שנתי");
+}
+
+#[test]
+fn test_enrich_adds_missing_courses_from_sibling() {
+    let mut chosen = make_catalog(
+        "מדמח תלת שנתי 2022-2023",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("23600001", "רשימה א")],
+    );
+
+    let sibling = make_catalog(
+        "מדמח תלת שנתי 2023-2024",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![
+            ("23600001", "רשימה א"), // already in chosen
+            ("23600002", "רשימה א"), // new course
+        ],
+    );
+
+    chosen.enrich_with_sibling_courses(&[sibling]);
+
+    assert_eq!(chosen.course_to_bank.len(), 2);
+    assert_eq!(
+        chosen.course_to_bank.get(&CourseId::new("23600002")),
+        Some(&"רשימה א".to_string())
+    );
+}
+
+#[test]
+fn test_enrich_does_not_override_existing_courses() {
+    let mut chosen = make_catalog(
+        "מדמח תלת שנתי 2022-2023",
+        vec![
+            ("רשימה א", Rule::AccumulateCredit),
+            ("רשימה ב", Rule::AccumulateCredit),
+        ],
+        vec![("23600001", "רשימה א")],
+    );
+
+    let sibling = make_catalog(
+        "מדמח תלת שנתי 2023-2024",
+        vec![("רשימה ב", Rule::AccumulateCredit)],
+        vec![("23600001", "רשימה ב")], // same course, different bank in sibling
+    );
+
+    chosen.enrich_with_sibling_courses(&[sibling]);
+
+    // The course should remain in "רשימה א" (chosen catalog priority)
+    assert_eq!(
+        chosen.course_to_bank.get(&CourseId::new("23600001")),
+        Some(&"רשימה א".to_string())
+    );
+    assert_eq!(chosen.course_to_bank.len(), 1);
+}
+
+#[test]
+fn test_enrich_only_merges_accumulate_banks() {
+    let mut chosen = make_catalog(
+        "מדמח תלת שנתי 2022-2023",
+        vec![("חובה", Rule::All), ("רשימה א", Rule::AccumulateCredit)],
+        vec![],
+    );
+
+    let sibling = make_catalog(
+        "מדמח תלת שנתי 2023-2024",
+        vec![("חובה", Rule::All), ("רשימה א", Rule::AccumulateCredit)],
+        vec![
+            ("23600001", "חובה"),    // from an All bank — should NOT be merged
+            ("23600002", "רשימה א"), // from AccumulateCredit — should be merged
+        ],
+    );
+
+    chosen.enrich_with_sibling_courses(&[sibling]);
+
+    assert_eq!(chosen.course_to_bank.len(), 1);
+    assert_eq!(
+        chosen.course_to_bank.get(&CourseId::new("23600002")),
+        Some(&"רשימה א".to_string())
+    );
+}
+
+#[test]
+fn test_enrich_skips_bank_not_in_chosen_catalog() {
+    let mut chosen = make_catalog(
+        "מדמח תלת שנתי 2022-2023",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![],
+    );
+
+    let sibling = make_catalog(
+        "מדמח תלת שנתי 2023-2024",
+        vec![("רשימה ג", Rule::AccumulateCredit)], // bank name doesn't exist in chosen
+        vec![("23600001", "רשימה ג")],
+    );
+
+    chosen.enrich_with_sibling_courses(&[sibling]);
+
+    assert_eq!(chosen.course_to_bank.len(), 0);
+}
+
+#[test]
+fn test_enrich_skips_self() {
+    let mut chosen = make_catalog(
+        "מדמח תלת שנתי 2022-2023",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("23600001", "רשימה א")],
+    );
+
+    // Pass itself as a sibling — should not duplicate anything
+    let mut clone = chosen.clone();
+    clone
+        .course_to_bank
+        .insert(CourseId::new("23600002"), "רשימה א".to_string()); // add a different course to the clone to ensure it's skipped.
+    chosen.enrich_with_sibling_courses(&[clone]);
+
+    assert_eq!(chosen.course_to_bank.len(), 1);
+}
+
+#[test]
+fn test_enrich_merges_accumulate_courses_bank() {
+    let mut chosen = make_catalog(
+        "מדמח תלת שנתי 2022-2023",
+        vec![("רשימה ב", Rule::AccumulateCourses(3))],
+        vec![("23600001", "רשימה ב")],
+    );
+
+    let sibling = make_catalog(
+        "מדמח תלת שנתי 2021-2022",
+        vec![("רשימה ב", Rule::AccumulateCourses(3))],
+        vec![("23600002", "רשימה ב")],
+    );
+
+    chosen.enrich_with_sibling_courses(&[sibling]);
+
+    assert_eq!(chosen.course_to_bank.len(), 2);
+    assert_eq!(
+        chosen.course_to_bank.get(&CourseId::new("23600002")),
+        Some(&"רשימה ב".to_string())
+    );
+}
+
+#[test]
+fn test_enrich_with_multiple_siblings() {
+    let mut chosen = make_catalog(
+        "מדמח תלת שנתי 2022-2023",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("23600001", "רשימה א")],
+    );
+
+    let sibling1 = make_catalog(
+        "מדמח תלת שנתי 2021-2022",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("23600002", "רשימה א")],
+    );
+    let sibling2 = make_catalog(
+        "מדמח תלת שנתי 2023-2024",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("23600003", "רשימה א")],
+    );
+
+    chosen.enrich_with_sibling_courses(&[sibling1, sibling2]);
+
+    assert_eq!(chosen.course_to_bank.len(), 3);
+    assert!(chosen
+        .course_to_bank
+        .contains_key(&CourseId::new("23600001")));
+    assert!(chosen
+        .course_to_bank
+        .contains_key(&CourseId::new("23600002")));
+    assert!(chosen
+        .course_to_bank
+        .contains_key(&CourseId::new("23600003")));
 }

--- a/packages/server/src/resources/tests.rs
+++ b/packages/server/src/resources/tests.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
-use super::catalog::Catalog;
-use super::course::{CourseBank, CourseId, CourseState, Grade};
+use super::catalog::{Catalog, Faculty};
+use super::course::{Course, CourseBank, CourseId, CourseState, CourseStatus, Grade};
 use crate::core::types::Rule;
 
 #[tokio::test]
@@ -272,4 +272,195 @@ fn test_enrich_with_multiple_siblings() {
     assert!(chosen
         .course_to_bank
         .contains_key(&CourseId::new("23600003")));
+}
+
+fn make_course_status(course_id: &str, credit: f32) -> CourseStatus {
+    CourseStatus {
+        course: Course {
+            id: CourseId::new(course_id),
+            credit,
+            name: format!("Course {course_id}"),
+            tags: None,
+        },
+        state: Some(CourseState::Complete),
+        grade: Some(Grade::Numeric(85)),
+        semester: Some("winter_1".to_string()),
+        modified: false,
+        ..Default::default()
+    }
+}
+
+// --- course_prefixes tests ---
+
+#[test]
+fn test_course_prefixes_computer_science() {
+    let catalog = Catalog {
+        faculty: Faculty::ComputerScience,
+        ..Default::default()
+    };
+    let prefixes = catalog.course_prefixes();
+    assert!(prefixes.contains(&"0234"));
+    assert!(prefixes.contains(&"0236"));
+}
+
+#[test]
+fn test_course_prefixes_unknown_faculty() {
+    let catalog = Catalog {
+        faculty: Faculty::Unknown,
+        ..Default::default()
+    };
+    assert!(catalog.course_prefixes().is_empty());
+}
+
+// --- default_accumulate_bank tests ---
+
+#[test]
+fn test_default_accumulate_bank_picks_largest() {
+    let catalog = make_catalog(
+        "test",
+        vec![
+            ("רשימה א", Rule::AccumulateCredit),
+            ("רשימה ב", Rule::AccumulateCredit),
+        ],
+        vec![
+            ("02340001", "רשימה א"),
+            ("02340002", "רשימה א"),
+            ("02340003", "רשימה א"),
+            ("02340004", "רשימה ב"),
+        ],
+    );
+    assert_eq!(
+        catalog.default_accumulate_bank(),
+        Some("רשימה א".to_string())
+    );
+}
+
+#[test]
+fn test_default_accumulate_bank_no_accumulate_banks() {
+    let catalog = make_catalog("test", vec![("חובה", Rule::All)], vec![("02340001", "חובה")]);
+    assert_eq!(catalog.default_accumulate_bank(), None);
+}
+
+#[test]
+fn test_default_accumulate_bank_empty_catalog() {
+    let catalog = Catalog::default();
+    assert_eq!(catalog.default_accumulate_bank(), None);
+}
+
+// --- enrich_with_prefix_courses tests ---
+
+#[test]
+fn test_enrich_prefix_adds_non_catalog_course() {
+    let mut catalog = make_catalog(
+        "מדמח 2023",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("02340001", "רשימה א")],
+    );
+    catalog.faculty = Faculty::ComputerScience;
+
+    let student_courses = vec![
+        make_course_status("02340001", 3.0), // already in catalog
+        make_course_status("02340099", 3.0), // NOT in catalog, has CS prefix
+    ];
+
+    catalog.enrich_with_prefix_courses(&student_courses);
+
+    assert_eq!(catalog.course_to_bank.len(), 2);
+    assert_eq!(
+        catalog.course_to_bank.get(&CourseId::new("02340099")),
+        Some(&"רשימה א".to_string())
+    );
+}
+
+#[test]
+fn test_enrich_prefix_does_not_override_existing() {
+    let mut catalog = make_catalog(
+        "מדמח 2023",
+        vec![
+            ("חובה", Rule::All),
+            ("רשימה א", Rule::AccumulateCredit),
+        ],
+        vec![
+            ("02340001", "חובה"), // already mapped to חובה
+            ("02340002", "רשימה א"),
+            ("02340003", "רשימה א"),
+        ],
+    );
+    catalog.faculty = Faculty::ComputerScience;
+
+    let student_courses = vec![make_course_status("02340001", 3.0)];
+
+    catalog.enrich_with_prefix_courses(&student_courses);
+
+    // Should remain in חובה, not moved to רשימה א
+    assert_eq!(
+        catalog.course_to_bank.get(&CourseId::new("02340001")),
+        Some(&"חובה".to_string())
+    );
+}
+
+#[test]
+fn test_enrich_prefix_no_prefixes_for_unknown_faculty() {
+    let mut catalog = make_catalog(
+        "test 2023",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("02340001", "רשימה א")],
+    );
+    catalog.faculty = Faculty::Unknown;
+
+    let student_courses = vec![make_course_status("02340099", 3.0)];
+
+    catalog.enrich_with_prefix_courses(&student_courses);
+
+    // Should NOT add the course since Unknown faculty has no prefixes
+    assert_eq!(catalog.course_to_bank.len(), 1);
+    assert!(!catalog
+        .course_to_bank
+        .contains_key(&CourseId::new("02340099")));
+}
+
+#[test]
+fn test_enrich_prefix_no_accumulate_banks() {
+    let mut catalog = make_catalog(
+        "מדמח 2023",
+        vec![("חובה", Rule::All)],
+        vec![("02340001", "חובה")],
+    );
+    catalog.faculty = Faculty::ComputerScience;
+
+    let student_courses = vec![make_course_status("02340099", 3.0)];
+
+    catalog.enrich_with_prefix_courses(&student_courses);
+
+    // Should NOT add since there's no accumulate bank
+    assert_eq!(catalog.course_to_bank.len(), 1);
+}
+
+#[test]
+fn test_enrich_prefix_multiple_prefixes() {
+    let mut catalog = make_catalog(
+        "מדמח 2023",
+        vec![("רשימה א", Rule::AccumulateCredit)],
+        vec![("02340001", "רשימה א")],
+    );
+    catalog.faculty = Faculty::ComputerScience;
+
+    let student_courses = vec![
+        make_course_status("02340099", 3.0), // prefix 0234
+        make_course_status("02360055", 3.0), // prefix 0236
+        make_course_status("09990001", 3.0), // non-matching prefix
+    ];
+
+    catalog.enrich_with_prefix_courses(&student_courses);
+
+    assert_eq!(catalog.course_to_bank.len(), 3); // original + 2 matched
+    assert!(catalog
+        .course_to_bank
+        .contains_key(&CourseId::new("02340099")));
+    assert!(catalog
+        .course_to_bank
+        .contains_key(&CourseId::new("02360055")));
+    assert!(!catalog
+        .course_to_bank
+        .contains_key(&CourseId::new("09990001")));
 }

--- a/packages/server/src/resources/tests.rs
+++ b/packages/server/src/resources/tests.rs
@@ -337,7 +337,11 @@ fn test_default_accumulate_bank_picks_largest() {
 
 #[test]
 fn test_default_accumulate_bank_no_accumulate_banks() {
-    let catalog = make_catalog("test", vec![("חובה", Rule::All)], vec![("02340001", "חובה")]);
+    let catalog = make_catalog(
+        "test",
+        vec![("חובה", Rule::All)],
+        vec![("02340001", "חובה")],
+    );
     assert_eq!(catalog.default_accumulate_bank(), None);
 }
 
@@ -376,10 +380,7 @@ fn test_enrich_prefix_adds_non_catalog_course() {
 fn test_enrich_prefix_does_not_override_existing() {
     let mut catalog = make_catalog(
         "מדמח 2023",
-        vec![
-            ("חובה", Rule::All),
-            ("רשימה א", Rule::AccumulateCredit),
-        ],
+        vec![("חובה", Rule::All), ("רשימה א", Rule::AccumulateCredit)],
         vec![
             ("02340001", "חובה"), // already mapped to חובה
             ("02340002", "רשימה א"),

--- a/packages/server/src/sap/mod.rs
+++ b/packages/server/src/sap/mod.rs
@@ -875,7 +875,11 @@ impl CachedSapClient {
             .collect()
     }
 
-    async fn fetch_course_ids(&self, year: &str, semester: &str) -> Result<Vec<CourseId>, SapError> {
+    async fn fetch_course_ids(
+        &self,
+        year: &str,
+        semester: &str,
+    ) -> Result<Vec<CourseId>, SapError> {
         let query = format!(
             "SmObjectSet?sap-client=700&$skip=0&$top=10000\
              &$filter=Peryr%20eq%20%27{year}%27%20and%20Perid%20eq%20%27{semester}%27\
@@ -2018,7 +2022,10 @@ mod tests {
 
     #[test]
     fn test_parse_corequisites() {
-        assert_eq!(parse_corequisites("מקצוע צמוד: 104031"), vec![CourseId::new("00104031")]);
+        assert_eq!(
+            parse_corequisites("מקצוע צמוד: 104031"),
+            vec![CourseId::new("00104031")]
+        );
         assert_eq!(
             parse_corequisites("מקצועות צמודים: 104031, 104166"),
             vec![CourseId::new("00104031"), CourseId::new("00104166")]

--- a/packages/server/src/sap/mod.rs
+++ b/packages/server/src/sap/mod.rs
@@ -1876,7 +1876,7 @@ fn parse_corequisites(note: &str) -> Vec<CourseId> {
     let num_re = Regex::new(r"\d{5,8}").unwrap();
     num_re
         .find_iter(content)
-        .map(|m| CourseId::new(format!("{:0>8}", m.as_str())))
+        .map(|m| CourseId::new(m.as_str()))
         .collect()
 }
 

--- a/packages/server/src/sap/mod.rs
+++ b/packages/server/src/sap/mod.rs
@@ -16,6 +16,8 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::resources::course::CourseId;
+
 const SAP_BASE_URL: &str =
     "https://portalex.technion.ac.il/sap/opu/odata/sap/Z_CM_EV_CDIR_DATA_SRV";
 const BATCH_BOUNDARY: &str = "batch_1d12-afbf-e3c7";
@@ -159,7 +161,7 @@ pub struct Semester {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CourseDetails {
-    pub id: String,
+    pub id: CourseId,
     pub name: String,
     pub credits: f32,
     pub faculty: Option<String>,
@@ -175,7 +177,7 @@ pub struct CourseDetails {
     pub exams: Vec<Exam>,
     pub relations: Vec<Relation>,
     pub prerequisites: Vec<PrereqToken>,
-    pub corequisites: Vec<String>,
+    pub corequisites: Vec<CourseId>,
     pub responsible: Vec<Person>,
     pub offered_periods: Vec<OfferedPeriod>,
     pub schedule: Vec<ScheduleGroup>,
@@ -195,7 +197,7 @@ pub struct Exam {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Relation {
-    pub course_id: String,
+    pub course_id: CourseId,
     #[serde(rename = "type")]
     pub relation_type: RelationType,
 }
@@ -390,7 +392,7 @@ struct RawPerson {
 /// Lightweight course entry for the search index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CourseIndexEntry {
-    pub id: String,
+    pub id: CourseId,
     pub name: String,
     pub faculty: Option<String>,
     pub credits: f32,
@@ -411,7 +413,7 @@ pub struct CachedSapClient {
     proxy_url: Option<String>,
     courses: Cache<String, Arc<CourseDetails>>,
     semesters: Cache<String, Arc<Vec<Semester>>>,
-    course_ids: Cache<String, Arc<Vec<String>>>,
+    course_ids: Cache<String, Arc<Vec<CourseId>>>,
     course_index: Cache<String, Arc<Vec<CourseIndexEntry>>>,
     /// Cached building names resolved via GObjectSet. Key: room OData ID.
     buildings: Cache<String, Option<String>>,
@@ -598,7 +600,7 @@ impl CachedSapClient {
         let semester = &current.semester;
 
         let semaphore = Arc::new(Semaphore::new(PREWARM_CONCURRENCY));
-        let chunks: Vec<Vec<String>> = ids.chunks(BATCH_SIZE).map(|c| c.to_vec()).collect();
+        let chunks: Vec<Vec<CourseId>> = ids.chunks(BATCH_SIZE).map(|c| c.to_vec()).collect();
 
         let handles: Vec<_> = chunks
             .into_iter()
@@ -716,7 +718,7 @@ impl CachedSapClient {
         self.fetch_total.fetch_add(ids.len(), Ordering::Relaxed);
 
         let semaphore = Arc::new(Semaphore::new(concurrency));
-        let chunks: Vec<Vec<String>> = ids.chunks(BATCH_SIZE).map(|c| c.to_vec()).collect();
+        let chunks: Vec<Vec<CourseId>> = ids.chunks(BATCH_SIZE).map(|c| c.to_vec()).collect();
 
         let handles: Vec<_> = chunks
             .into_iter()
@@ -842,7 +844,7 @@ impl CachedSapClient {
         &self,
         year: &str,
         semester: &str,
-    ) -> Result<Arc<Vec<String>>, SapError> {
+    ) -> Result<Arc<Vec<CourseId>>, SapError> {
         let key = format!("{year}/{semester}");
         if let Some(cached) = self.course_ids.get(&key).await {
             return Ok(cached);
@@ -873,7 +875,7 @@ impl CachedSapClient {
             .collect()
     }
 
-    async fn fetch_course_ids(&self, year: &str, semester: &str) -> Result<Vec<String>, SapError> {
+    async fn fetch_course_ids(&self, year: &str, semester: &str) -> Result<Vec<CourseId>, SapError> {
         let query = format!(
             "SmObjectSet?sap-client=700&$skip=0&$top=10000\
              &$filter=Peryr%20eq%20%27{year}%27%20and%20Perid%20eq%20%27{semester}%27\
@@ -1861,7 +1863,7 @@ fn format_person(persons: &[RawPerson]) -> Option<String> {
 
 /// Parse corequisites from semester notes. Looks for lines like:
 /// "מקצוע צמוד: 01040031" or "מקצועות צמודים: 01040031, 01041066"
-fn parse_corequisites(note: &str) -> Vec<String> {
+fn parse_corequisites(note: &str) -> Vec<CourseId> {
     let re = Regex::new(r"מקצועו?ת? צמודי?ם?:\s*(.+)").unwrap();
     let Some(caps) = re.captures(note) else {
         return vec![];
@@ -1870,7 +1872,7 @@ fn parse_corequisites(note: &str) -> Vec<String> {
     let num_re = Regex::new(r"\d{5,8}").unwrap();
     num_re
         .find_iter(content)
-        .map(|m| format!("{:0>8}", m.as_str()))
+        .map(|m| CourseId::new(format!("{:0>8}", m.as_str())))
         .collect()
 }
 
@@ -1882,8 +1884,8 @@ pub fn course_number_to_sap_id(number: &str) -> String {
 
 /// Strip the `SM` prefix from a SAP OData entity ID.
 /// Returns the 8-digit course number (e.g. "02340114").
-pub fn sap_id_to_course_number(sap_id: &str) -> String {
-    sap_id.trim_start_matches("SM").to_string()
+pub fn sap_id_to_course_number(sap_id: &str) -> CourseId {
+    CourseId::new(sap_id.trim_start_matches("SM"))
 }
 
 fn parse_sap_date_epoch(date_str: &str) -> Option<i64> {
@@ -1918,8 +1920,8 @@ mod tests {
     fn test_course_number_conversions() {
         assert_eq!(course_number_to_sap_id("02340114"), "SM02340114");
         assert_eq!(course_number_to_sap_id("01040031"), "SM01040031");
-        assert_eq!(sap_id_to_course_number("SM02340114"), "02340114");
-        assert_eq!(sap_id_to_course_number("SM97030012"), "97030012");
+        assert_eq!(*sap_id_to_course_number("SM02340114"), *"02340114");
+        assert_eq!(*sap_id_to_course_number("SM97030012"), *"97030012");
     }
 
     #[test]
@@ -2016,12 +2018,12 @@ mod tests {
 
     #[test]
     fn test_parse_corequisites() {
-        assert_eq!(parse_corequisites("מקצוע צמוד: 104031"), vec!["00104031"]);
+        assert_eq!(parse_corequisites("מקצוע צמוד: 104031"), vec![CourseId::new("00104031")]);
         assert_eq!(
             parse_corequisites("מקצועות צמודים: 104031, 104166"),
-            vec!["00104031", "00104166"]
+            vec![CourseId::new("00104031"), CourseId::new("00104166")]
         );
-        assert_eq!(parse_corequisites("no coreqs here"), Vec::<String>::new());
+        assert_eq!(parse_corequisites("no coreqs here"), Vec::<CourseId>::new());
     }
 
     // Integration tests below require SAP API access.
@@ -2071,7 +2073,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(d1.name, "מבוא למדעי המחשב מ'");
-        assert_eq!(d1.id, "02340114");
+        assert_eq!(*d1.id, *"02340114");
         assert!(d1.credits > 0.0);
         assert!(!d1.exams.is_empty());
         assert!(d1.exams.len() < 10); // deduped

--- a/packages/server/src/sap/mod.rs
+++ b/packages/server/src/sap/mod.rs
@@ -1776,7 +1776,7 @@ fn resolve_building_code(code: &str) -> Option<&'static str> {
     // This list is derived from GObjectSet results + the SAP
     // building names normalized the same way he does (strip "בנין"/"בניין" prefix).
     match code {
-        "014" => Some("טאוב"),
+        "014" => Some("אולמן"),
         "015" => Some("אולם צ'רצ'יל"),
         "016" => Some("הנ' כימית"),
         "018" => Some("הנ' מכונות"),
@@ -1800,7 +1800,7 @@ fn resolve_building_code(code: &str) -> Option<&'static str> {
         "056" => Some("מדע החלטות"),
         "058" => Some("סגו"),
         "060" => Some("ביוטכנולוגיה ומדעי המזון"),
-        "069" => Some("דן קהאן"),
+        "069" => Some("טאוב"),
         "071" => Some("ספריה מרכזית"),
         "079" => Some("הנדסת חמרים"),
         "084" => Some("מדעי המחשב"),

--- a/packages/server/src/sap/mod.rs
+++ b/packages/server/src/sap/mod.rs
@@ -2024,11 +2024,11 @@ mod tests {
     fn test_parse_corequisites() {
         assert_eq!(
             parse_corequisites("מקצוע צמוד: 104031"),
-            vec![CourseId::new("00104031")]
+            vec![CourseId::new("104031")]
         );
         assert_eq!(
             parse_corequisites("מקצועות צמודים: 104031, 104166"),
-            vec![CourseId::new("00104031"), CourseId::new("00104166")]
+            vec![CourseId::new("104031"), CourseId::new("104166")]
         );
         assert_eq!(parse_corequisites("no coreqs here"), Vec::<CourseId>::new());
     }

--- a/packages/sogrim-app-v2/src/components/planner/planner-page.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/planner-page.tsx
@@ -61,12 +61,7 @@ export function PlannerPage() {
   const details = userState?.details;
   const registrationState = getRegistrationState(details);
 
-  const rawCourseStatuses = details?.degree_status.course_statuses ?? [];
-  const courseStatuses = rawCourseStatuses.map((cs) =>
-    cs.course.credit === 0 && cs.grade === "פטור ללא ניקוד"
-      ? { ...cs, semester: null }
-      : cs
-  );
+  const courseStatuses = details?.degree_status.course_statuses ?? [];
   const bankNames = details?.catalog?.course_bank_names ?? [];
 
   const hasNullSemester = courseStatuses.some((cs) => cs.semester === null);

--- a/packages/sogrim-app-v2/src/components/settings/settings-page.tsx
+++ b/packages/sogrim-app-v2/src/components/settings/settings-page.tsx
@@ -262,7 +262,7 @@ export function SettingsPage() {
                 <Label htmlFor="catalog-select">מסלול לימודים</Label>
                 <Combobox
                   id="catalog-select"
-                  value={currentCatalogId || ""}
+                  value={pendingCatalogId || currentCatalogId || ""}
                   onChange={handleCatalogChange}
                   disabled={updateCatalog.isPending}
                   placeholder="בחר קטלוג..."

--- a/packages/sogrim-app-v2/src/components/timetable/semester-selector.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/semester-selector.tsx
@@ -7,12 +7,7 @@ export function SemesterSelector() {
   const currentSemester = useTimetableStore((s) => s.currentSemester);
   const setSemester = useTimetableStore((s) => s.setSemester);
 
-  let semesters: { id: string; name: string }[] = [];
-  try {
-    semesters = getProvider().getSemesters();
-  } catch {
-    semesters = [{ id: "spring-2026", name: "אביב 2026" }];
-  }
+  let semesters = getProvider().getSemesters();
 
   return (
     <Dropdown

--- a/packages/sogrim-app-v2/src/components/timetable/week-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/week-grid.tsx
@@ -3,8 +3,6 @@ import type { Day, TimetableEvent } from "@/types/timetable";
 import {
   DAY_NAMES,
   WEEKDAYS,
-  DEFAULT_START_HOUR,
-  DEFAULT_END_HOUR,
   SLOT_MINUTES,
   getTimeLabels,
   totalSlots,
@@ -211,7 +209,6 @@ function layoutEvents(
   const eventGroups: number[] = []; // which overlap group each event belongs to
   const groupMaxCols: number[] = []; // max columns used per group
 
-  let currentGroupStart = 0;
   let currentGroupEnd = 0;
   let groupIndex = -1;
 
@@ -223,7 +220,7 @@ function layoutEvents(
     // Check if this event starts a new non-overlapping group
     if (evStart >= currentGroupEnd) {
       groupIndex++;
-      currentGroupStart = evStart;
+      // new group starts at evStart
       currentGroupEnd = evEnd;
       columns.length = 0; // reset columns for new group
     } else {

--- a/packages/sogrim-app-v2/src/data/api-provider.ts
+++ b/packages/sogrim-app-v2/src/data/api-provider.ts
@@ -282,7 +282,7 @@ export class ApiProvider implements CourseScheduleProvider {
       .filter((s) => ["200", "201", "202"].includes(s.semester))
       .map((s) => ({
         id: `${s.year}-${s.semester}`,
-        name: `${semesterCodeToName(s.semester)} ${parseInt(s.year) + 1}`,
+        name: `${semesterCodeToName(s.semester)} ${parseInt(s.year) + (s.semester === "200" ? 0 : 1)}`,
         year: parseInt(s.year),
         season: semesterCodeToSeason(s.semester),
       }));

--- a/packages/sogrim-app-v2/src/lib/timetable-utils.ts
+++ b/packages/sogrim-app-v2/src/lib/timetable-utils.ts
@@ -131,9 +131,3 @@ export function generateDraftId(): string {
   return `draft-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 }
 
-/** Hebrew draft name by index */
-const DRAFT_LETTERS = ["א", "ב", "ג", "ד", "ה", "ו", "ז", "ח"];
-export function defaultDraftName(index: number): string {
-  const letter = DRAFT_LETTERS[index] ?? String(index + 1);
-  return `אפשרות ${letter}׳`;
-}

--- a/packages/sogrim-app-v2/src/stores/timetable-store.ts
+++ b/packages/sogrim-app-v2/src/stores/timetable-store.ts
@@ -10,7 +10,7 @@ import type {
   ViewMode,
 } from "@/types/timetable";
 import { getProvider } from "@/data/course-schedule-provider";
-import { generateDraftId, defaultDraftName } from "@/lib/timetable-utils";
+import { generateDraftId } from "@/lib/timetable-utils";
 import { getConflictingEventKeys, eventKey } from "@/lib/timetable-conflicts";
 
 interface TimetableState {
@@ -26,6 +26,7 @@ interface TimetableState {
   currentSemester: string;
   drafts: TimetableDraft[];
   activeDraftId: string | null;
+  draftCounter: number;
 
   // Sync status
   _loaded: boolean;   // true only after successful backend load
@@ -89,6 +90,7 @@ export const useTimetableStore = create<TimetableState>()(
       currentSemester: "",
       drafts: [],
       activeDraftId: null,
+      draftCounter: 0,
       _loaded: false,
       _syncing: false,
       _lastSaved: 0,
@@ -114,12 +116,12 @@ export const useTimetableStore = create<TimetableState>()(
       createDraft: (semester) => {
         const state = get();
         const sem = semester ?? state.currentSemester;
-        const semDrafts = state.drafts.filter((d) => d.semester === sem);
+        const next = state.draftCounter + 1;
         const id = generateDraftId();
         const now = new Date().toISOString();
         const newDraft: TimetableDraft = {
           id,
-          name: defaultDraftName(semDrafts.length),
+          name: `אפשרות ${next}`,
           semester: sem,
           courses: [],
           customEvents: [],
@@ -130,6 +132,7 @@ export const useTimetableStore = create<TimetableState>()(
         set({
           drafts: [...state.drafts, newDraft],
           activeDraftId: id,
+          draftCounter: next,
         });
         return id;
       },


### PR DESCRIPTION
Refactor CourseId from a plain type alias (String) into a dedicated struct that automatically normalizes 6-digit course IDs to 8-digit format on construction. This ensures consistent IDs across the entire codebase and eliminates scattered conversion logic.

  Core: CourseId struct (course.rs)

   - Converted CourseId from type CourseId = String to a proper struct with auto 6→8 digit normalization
   - Two conversion rules: Standard ABCDEF → 0ABC0DEF / Non-standard (faculties 51, 52, 61, 97) ABCDEF → AB0C0DEF
   - Implemented Deref, Display, Serialize/Deserialize, Borrow<str>, From<CourseId> for bson::Bson
   - Added From<&CourseDetails> for Course and unit tests

  Preprocessing cleanup (preprocessing.rs)

   - Removed old to_8digit() and normalize_course_ids() — now handled at CourseId level
   - Added catalog.enrich_with_prefix_courses() during preprocessing

  Catalog enhancements (catalog.rs)

   - Faculty-based course ID prefix support (course_prefixes())
   - enrich_with_prefix_courses() to auto-add student courses matching faculty prefix to largest accumulate bank

  Disk cache improvements (disk_cache.rs)

   - Flat deduplicated all_courses map built from all semesters (newest wins)
   - Added get_all_courses() and get_courses_by_filter() methods
   - load_all() iterates oldest-first so newer semesters overwrite

  API changes (admins.rs, students.rs)

   - Endpoints pull courses from DiskCourseCache instead of MongoDB
   - Removed FilterOption / get_filtered DB calls

  SAP & fetcher (sap/mod.rs, fetcher.rs)

   - CourseDetails, Relation, CourseIndexEntry, MissingCourse use CourseId
   - corequisites changed from Vec<String> to Vec<CourseId>

  Frontend fixes

   - Semester naming (api-provider.ts): Fixed year calc — winter semester no longer adds +1
   - Semester selector: Removed unnecessary try/catch fallback
   - Draft numbering (timetable-store.ts): Persistent draftCounter replaces letter-based naming
   - Planner (planner-page.tsx): Removed client-side exemption-course hack
   - Week grid (week-grid.tsx): Removed unused imports/variables