### PR TITLE
SAP fetcher overhaul + timetable improvements + custom UI dropdowns

### DIFF
--- a/packages/server/src/sap/mod.rs
+++ b/packages/server/src/sap/mod.rs
@@ -28,6 +28,72 @@ const INITIAL_BACKOFF_MS: u64 = 500;
 /// Groups to filter out from the schedule.
 const FILTERED_GROUPS: &[&str] = &["077", "069", "086"];
 
+/// Check if a course is a sport course (03940800-03940999).
+fn is_sport_course(course_id: &str) -> bool {
+    course_id.starts_with("03940")
+        && course_id.len() == 8
+        && matches!(course_id.as_bytes().get(5), Some(b'8' | b'9'))
+}
+
+const HUMANITIES_FACULTY: &str = "המחלקה ללימודים הומניסטיים ואמנות";
+
+/// Non-humanities courses that are explicitly malags.
+const MALAG_EXPLICIT_IDS: &[&str] = &["02140119", "02140120", "02750112"];
+
+/// Name patterns for language courses (not malag).
+const LANGUAGE_KEYWORDS: &[&str] = &[
+    "אנגלית",
+    "עברית",
+    "סינית",
+    "יפנית",
+    "צרפתית",
+    "גרמנית",
+    "רוסית",
+    "ערבית",
+    "ספרדית",
+    "איטלקית",
+    "שיחה ב",
+];
+
+/// Name patterns for art/performance/studio courses (not malag).
+const ART_KEYWORDS: &[&str] = &[
+    "רישום",
+    "ציור",
+    "תזמורת",
+    "כוריאוגרפיה",
+    "סדנת צילום",
+    "מחזה-הצגה",
+    "סטודיו אומן",
+    "עיצוב גרפי",
+];
+
+/// Classify whether a course is a malag (enrichment) course.
+/// Humanities department + 2 credits = malag, unless it's a language,
+/// art/performance, or academic writing course.
+fn classify_malag(id: &str, name: &str, credits: f32, faculty: Option<&str>) -> bool {
+    if MALAG_EXPLICIT_IDS.contains(&id) {
+        return true;
+    }
+
+    if faculty != Some(HUMANITIES_FACULTY) || credits != 2.0 {
+        return false;
+    }
+
+    if LANGUAGE_KEYWORDS.iter().any(|kw| name.contains(kw)) {
+        return false;
+    }
+
+    if ART_KEYWORDS.iter().any(|kw| name.contains(kw)) {
+        return false;
+    }
+
+    if name.contains("כתיבה אקדמית") {
+        return false;
+    }
+
+    true
+}
+
 // ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
@@ -99,6 +165,12 @@ pub struct CourseDetails {
     pub faculty: Option<String>,
     pub syllabus: Option<String>,
     pub academic_level: Option<String>,
+    /// True if the course is taught in English.
+    pub is_english: bool,
+    /// True if this course qualifies as a malag (enrichment) course.
+    pub is_malag: bool,
+    /// True if this is a sport course (03940800-03940999).
+    pub is_sport: bool,
     pub semester_note: Option<String>,
     pub exams: Vec<Exam>,
     pub relations: Vec<Relation>,
@@ -116,6 +188,9 @@ pub struct Exam {
     pub date: Option<String>,
     pub begin_time: Option<String>,
     pub end_time: Option<String>,
+    /// Exam-specific note (e.g. special seating, group restrictions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -161,14 +236,17 @@ pub struct OfferedPeriod {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduleGroup {
     pub group: String,
+    /// Group-level name from SAP (e.g. "נבחרת טניס נשים" for sport courses).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub events: Vec<ScheduleEvent>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScheduleEvent {
-    /// e.g. "הרצאה", "תרגול", "מעבדה"
+    /// e.g. "הרצאה", "תרגול", "מעבדה", or sport-specific name like "נבחרת טניס נשים"
     pub kind: String,
-    /// Day of week: 0=Sunday, 1=Monday, ..., 4=Thursday
+    /// Day of week: 0=Sunday, 1=Monday, ..., 5=Friday
     #[serde(skip_serializing_if = "Option::is_none")]
     pub day: Option<u8>,
     /// "HH:MM"
@@ -202,6 +280,7 @@ struct RawCourse {
     study_content_description: Option<String>,
     org_text: Option<String>,
     zz_academic_level_text: Option<String>,
+    zz_sm_language: Option<String>,
     zz_semester_note: Option<String>,
 }
 
@@ -213,6 +292,12 @@ struct RawExam {
     exam_date: Option<String>,
     exam_beg_time: Option<String>,
     exam_end_time: Option<String>,
+    /// Exam-level note/comment from SAP.
+    zz_se_comment: Option<String>,
+    /// GUID for parent/child exam hierarchy.
+    zz_exam_offer_guid: Option<String>,
+    /// Parent GUID — non-empty means this is a sub-exam (e.g. time slot under a date).
+    zz_exam_offer_parent_guid: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -252,8 +337,12 @@ struct RawOfferedPeriod {
 struct RawEObject {
     otjid: String,
     category_text: String,
+    /// Event-level name (e.g. "נבחרת טניס נשים" for sport courses).
+    name: Option<String>,
     schedule_summary: Option<String>,
     room_text: Option<String>,
+    /// Room OData ID for building lookup via GObjectSet.
+    room_id: Option<String>,
     #[serde(default)]
     persons: RawPersons,
 }
@@ -324,6 +413,8 @@ pub struct CachedSapClient {
     semesters: Cache<String, Arc<Vec<Semester>>>,
     course_ids: Cache<String, Arc<Vec<String>>>,
     course_index: Cache<String, Arc<Vec<CourseIndexEntry>>>,
+    /// Cached building names resolved via GObjectSet. Key: room OData ID.
+    buildings: Cache<String, Option<String>>,
     fetch_total: AtomicUsize,
     fetch_done: AtomicUsize,
     /// Total bytes sent to SAP (request bodies)
@@ -358,6 +449,7 @@ impl CachedSapClient {
             semesters: Cache::builder().time_to_live(ttl).max_capacity(1).build(),
             course_ids: Cache::builder().time_to_live(ttl).max_capacity(20).build(),
             course_index: Cache::builder().time_to_live(ttl).max_capacity(20).build(),
+            buildings: Cache::builder().time_to_live(ttl).max_capacity(500).build(),
             fetch_total: AtomicUsize::new(0),
             fetch_done: AtomicUsize::new(0),
             bytes_sent: AtomicUsize::new(0),
@@ -567,11 +659,16 @@ impl CachedSapClient {
                     };
 
                     for (i, course_number) in chunk.iter().enumerate() {
-                        match client.assemble_course(
-                            &detail_results[i],
-                            &sched_persons_results[i],
-                            &sched_times_results[i],
-                        ) {
+                        match client
+                            .assemble_course(
+                                &detail_results[i],
+                                &sched_persons_results[i],
+                                &sched_times_results[i],
+                                &year,
+                                &semester,
+                            )
+                            .await
+                        {
                             Ok(details) => {
                                 let key = format!("{year}/{semester}/{course_number}");
                                 client.courses.insert(key, Arc::new(details)).await;
@@ -683,7 +780,9 @@ impl CachedSapClient {
                             &detail_results[i],
                             &sched_persons_results[i],
                             &sched_times_results[i],
-                        ) {
+                            &year,
+                            &semester,
+                        ).await {
                             Ok(details) => {
                                 let key = format!("{year}/{semester}/{course_number}");
                                 client.courses.insert(key, Arc::new(details)).await;
@@ -807,15 +906,24 @@ impl CachedSapClient {
             self.batch_get(&sched_persons_query),
             self.batch_get(&sched_times_query),
         )?;
-        self.assemble_course(&detail_val, &sched_persons_val, &sched_times_val)
+        self.assemble_course(
+            &detail_val,
+            &sched_persons_val,
+            &sched_times_val,
+            year,
+            semester,
+        )
+        .await
     }
 
     /// Assemble a `CourseDetails` from pre-fetched detail + schedule (persons) + schedule (times).
-    fn assemble_course(
+    async fn assemble_course(
         &self,
         detail_val: &Value,
         sched_persons_val: &Value,
         sched_times_val: &Value,
+        year: &str,
+        semester: &str,
     ) -> Result<CourseDetails, SapError> {
         let mut results = Self::extract_results(detail_val.clone())?;
         let raw = results
@@ -830,7 +938,7 @@ impl CachedSapClient {
             .map(parse_corequisites)
             .unwrap_or_default();
 
-        let exams = Self::dedup_exams(Self::nested_results(&raw, "Exams"));
+        let exams = Self::parse_exams(Self::nested_results(&raw, "Exams"));
         let relations = Self::parse_relations(Self::nested_results(&raw, "SmRelations"));
         let prerequisites = Self::parse_prerequisites(Self::nested_results(&raw, "SmPrereq"));
 
@@ -858,15 +966,32 @@ impl CachedSapClient {
             })
             .collect();
 
-        let schedule = Self::parse_schedule(sched_persons_val, sched_times_val)?;
+        let course_id = sap_id_to_course_number(&course.otjid);
+        let schedule = self
+            .parse_schedule(
+                sched_persons_val,
+                sched_times_val,
+                &course_id,
+                year,
+                semester,
+            )
+            .await?;
+
+        let name = course.name.trim().to_string();
+        let faculty = course.org_text.filter(|s| !s.is_empty());
+        let is_malag = classify_malag(&course_id, &name, credits, faculty.as_deref());
+        let is_sport = is_sport_course(&course_id);
 
         Ok(CourseDetails {
-            id: sap_id_to_course_number(&course.otjid),
-            name: course.name.trim().to_string(),
+            id: course_id,
+            name,
             credits,
-            faculty: course.org_text.filter(|s| !s.is_empty()),
+            faculty,
             syllabus: course.study_content_description.filter(|s| !s.is_empty()),
             academic_level: course.zz_academic_level_text.filter(|s| !s.is_empty()),
+            is_english: course.zz_sm_language.as_deref() == Some("E"),
+            is_malag,
+            is_sport,
             semester_note: course.zz_semester_note.filter(|s| !s.is_empty()),
             exams,
             relations,
@@ -882,24 +1007,32 @@ impl CachedSapClient {
     /// - `persons_val`: SeObjectSet expanded with EObjectSet + EObjectSet/Persons
     /// - `times_val`: SeObjectSet expanded with EObjectSet + EObjectSet/Schedule
     ///   We merge them by matching on EObjectSet Otjid.
-    fn parse_schedule(
+    ///
+    /// `course_id` is the 8-digit course number, used for sport-course name logic.
+    async fn parse_schedule(
+        &self,
         persons_val: &Value,
         times_val: &Value,
+        course_id: &str,
+        year: &str,
+        semester: &str,
     ) -> Result<Vec<ScheduleGroup>, SapError> {
         let persons_groups = Self::extract_results(persons_val.clone())?;
         let times_groups = Self::extract_results(times_val.clone())?;
 
-        type ScheduleTime = (Option<u8>, Option<String>, Option<String>);
-        let mut time_map: HashMap<String, ScheduleTime> = HashMap::new();
+        // Build map: EObject Otjid → all structured time slots.
+        let mut time_map: HashMap<String, Vec<ScheduleTimeSlot>> = HashMap::new();
         for tg in &times_groups {
             for ev in Self::nested_results(tg, "EObjectSet") {
                 if let Ok(te) = serde_json::from_value::<RawEObjectTimes>(ev) {
-                    let time_info = extract_schedule_time(&te.schedule);
-                    time_map.insert(te.otjid, time_info);
+                    let slots = extract_all_schedule_times(&te.schedule);
+                    time_map.insert(te.otjid, slots);
                 }
             }
         }
 
+        let is_sport = is_sport_course(course_id);
+        let se_prefix_re = Regex::new(r"^SE\d+\s*").unwrap();
         let mut groups = Vec::new();
 
         for gv in persons_groups {
@@ -913,6 +1046,13 @@ impl CachedSapClient {
                 continue;
             }
 
+            // Group-level name from SeObjectSet (e.g. "SE11 נבחרת טניס נשים").
+            let group_name_raw = gv
+                .get("Name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
             let events_raw = Self::nested_results(&gv, "EObjectSet");
             let mut events = Vec::new();
 
@@ -922,37 +1062,161 @@ impl CachedSapClient {
                     Err(_) => continue,
                 };
 
-                let (day, start_time, end_time) = time_map
-                    .get(&e.otjid)
-                    .cloned()
-                    .unwrap_or((None, None, None));
+                // Resolve event kind — for sport courses, use the specific team name.
+                let kind = if is_sport {
+                    resolve_sport_kind(
+                        &e.category_text,
+                        e.name.as_deref(),
+                        &group_name_raw,
+                        course_id,
+                    )
+                } else {
+                    e.category_text.clone()
+                };
 
-                let (building, room) = e
-                    .room_text
-                    .as_deref()
-                    .filter(|r| !r.is_empty())
-                    .map(resolve_room)
-                    .unwrap_or((None, None));
+                // Resolve building/room — prefer RoomId-based lookup, fall back to
+                // code-based resolution from RoomText.
+                let (building, room) = self
+                    .resolve_building_and_room(
+                        e.room_text.as_deref(),
+                        e.room_id.as_deref(),
+                        year,
+                        semester,
+                    )
+                    .await;
 
-                events.push(ScheduleEvent {
-                    kind: e.category_text,
-                    day,
-                    start_time,
-                    end_time,
-                    schedule_text: e.schedule_summary.unwrap_or_default(),
-                    building,
-                    room,
-                    lecturer: format_person(&e.persons.results),
-                });
+                let lecturer = format_person(&e.persons.results);
+                let schedule_text = e.schedule_summary.clone().unwrap_or_default();
+
+                // Expand into one ScheduleEvent per time slot (GAP 6).
+                let slots = time_map.get(&e.otjid);
+                if let Some(slots) = slots.filter(|s| !s.is_empty()) {
+                    for slot in slots {
+                        // Filter out buggy near-zero-duration entries (GAP 11).
+                        if is_buggy_time_slot(slot) {
+                            continue;
+                        }
+                        events.push(ScheduleEvent {
+                            kind: kind.clone(),
+                            day: slot.day,
+                            start_time: slot.start_time.clone(),
+                            end_time: slot.end_time.clone(),
+                            schedule_text: schedule_text.clone(),
+                            building: building.clone(),
+                            room: room.clone(),
+                            lecturer: lecturer.clone(),
+                        });
+                    }
+                } else {
+                    // No structured time data — emit event with None day/times,
+                    // the schedule_text still provides human-readable info.
+                    events.push(ScheduleEvent {
+                        kind,
+                        day: None,
+                        start_time: None,
+                        end_time: None,
+                        schedule_text,
+                        building,
+                        room,
+                        lecturer,
+                    });
+                }
             }
+
+            // Deduplicate events that are identical (can happen with multi-entry schedules).
+            events.dedup();
+
+            // Resolve group-level name for sport courses.
+            let group_display_name = if is_sport {
+                let cleaned = se_prefix_re.replace(&group_name_raw, "").to_string();
+                Some(cleaned).filter(|s| !s.is_empty())
+            } else {
+                None
+            };
 
             groups.push(ScheduleGroup {
                 group: group_number,
+                name: group_display_name,
                 events,
             });
         }
 
         Ok(groups)
+    }
+
+    /// Resolve building name and room number from SAP room data.
+    /// Uses the static building code map first; on miss, queries GObjectSet
+    /// and caches the result for the lifetime of the client.
+    async fn resolve_building_and_room(
+        &self,
+        room_text: Option<&str>,
+        room_id: Option<&str>,
+        year: &str,
+        semester: &str,
+    ) -> (Option<String>, Option<String>) {
+        let room_text = match room_text.filter(|r| !r.is_empty() && *r != "ראה פרטים") {
+            Some(r) => r,
+            None => return (None, None),
+        };
+
+        let parts: Vec<&str> = room_text.split('-').collect();
+        if parts.len() != 2 {
+            return (None, Some(room_text.to_string()));
+        }
+        let building_code = parts[0];
+        let room_number = parts[1].trim_start_matches('0');
+        let room_num = if room_number.is_empty() {
+            parts[1]
+        } else {
+            room_number
+        };
+
+        // Try static map first (fast path, covers most buildings).
+        if let Some(name) = resolve_building_code(building_code) {
+            return (Some(name.to_string()), Some(room_num.to_string()));
+        }
+
+        // Dynamic lookup via GObjectSet, cached per room_id.
+        if let Some(rid) = room_id.filter(|r| !r.is_empty()) {
+            let building = self.get_building_name(rid, year, semester).await;
+            return (building, Some(room_num.to_string()));
+        }
+
+        (None, Some(room_num.to_string()))
+    }
+
+    /// Fetch building name from GObjectSet, with moka cache.
+    async fn get_building_name(&self, room_id: &str, year: &str, semester: &str) -> Option<String> {
+        // Check cache.
+        if let Some(cached) = self.buildings.get(room_id).await {
+            return cached;
+        }
+
+        let query = format!(
+            "GObjectSet(Otjid='{}',Peryr='{year}',Perid='{semester}')?sap-client=700&$select=Building",
+            urlencoding::encode(room_id)
+        );
+
+        let result = match self.batch_get(&query).await {
+            Ok(val) => {
+                let building = val
+                    .get("d")
+                    .and_then(|d| d.get("Building"))
+                    .and_then(|b| b.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(normalize_building_name);
+                building
+            }
+            Err(e) => {
+                log::debug!(target: "sogrim_server", "GObjectSet lookup failed for {room_id}: {e}");
+                None
+            }
+        };
+
+        self.buildings
+            .insert(room_id.to_string(), result.clone())
+            .await;
+        result
     }
 
     fn detail_query(year: &str, semester: &str, sap_id: &str) -> String {
@@ -961,7 +1225,7 @@ impl CachedSapClient {
              %20and%20Otjid%20eq%20%27{sap_id}%27"
         );
         let select = "Otjid,Points,Name,StudyContentDescription,OrgText,\
-                       ZzAcademicLevel,ZzAcademicLevelText,ZzSemesterNote,\
+                       ZzAcademicLevel,ZzAcademicLevelText,ZzSmLanguage,ZzSemesterNote,\
                        Responsible,Exams,SmRelations,SmPrereq,SmOfferedPeriodSet";
         let expand = "Responsible,Exams,SmRelations,SmPrereq,SmOfferedPeriodSet";
         format!("SmObjectSet?sap-client=700&$filter={filter}&$select={select}&$expand={expand}")
@@ -975,9 +1239,16 @@ impl CachedSapClient {
     }
 
     /// Schedule query expanding Persons (for lecturer names).
+    /// Selects Name at both SeObjectSet and EObjectSet level (for sport course names),
+    /// plus RoomId for building lookup.
     fn schedule_query_persons(year: &str, semester: &str, sap_id: &str) -> String {
         format!(
-            "{}&$expand=EObjectSet,EObjectSet/Persons",
+            "{}&$select=ZzSeSeqnr,Name,\
+             EObjectSet/Otjid,EObjectSet/CategoryText,EObjectSet/Name,\
+             EObjectSet/ScheduleSummary,EObjectSet/ScheduleText,\
+             EObjectSet/RoomText,EObjectSet/RoomId,\
+             EObjectSet/Persons/Title,EObjectSet/Persons/FirstName,EObjectSet/Persons/LastName\
+             &$expand=EObjectSet,EObjectSet/Persons",
             Self::schedule_entity(year, semester, sap_id)
         )
     }
@@ -1180,27 +1451,127 @@ impl CachedSapClient {
     // Data processing
     // -----------------------------------------------------------------------
 
-    fn dedup_exams(raw_exams: Vec<Value>) -> Vec<Exam> {
-        let mut seen = HashSet::new();
-        let mut result = Vec::new();
-        for v in raw_exams {
-            let e: RawExam = match serde_json::from_value(v) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
+    /// Parse exams with parent/child hierarchy handling.
+    /// SAP returns root exam entries (date only) and child entries (date + time).
+    /// When both exist for the same date, we keep only the child (with time).
+    /// Also handles quiz exams (MI, M2) and exam notes (ZzSeComment).
+    fn parse_exams(raw_exams: Vec<Value>) -> Vec<Exam> {
+        let parsed: Vec<RawExam> = raw_exams
+            .into_iter()
+            .filter_map(|v| serde_json::from_value(v).ok())
+            .collect();
+
+        // Identify root exam GUIDs so we can detect parent vs child.
+        let root_guids: HashSet<&str> = parsed
+            .iter()
+            .filter(|e| {
+                e.zz_exam_offer_parent_guid
+                    .as_deref()
+                    .is_none_or(|s| s.is_empty())
+            })
+            .filter_map(|e| e.zz_exam_offer_guid.as_deref())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        // Track which (category_code, date, note) combos have a child with time,
+        // so we can suppress the parent's timeless entry.
+        let mut dates_with_time: HashSet<(String, String, String)> = HashSet::new();
+
+        struct ExamEntry {
+            category: String,
+            category_code: String,
+            date: Option<String>,
+            begin_time: Option<String>,
+            end_time: Option<String>,
+            note: Option<String>,
+            is_child: bool,
+        }
+
+        let mut entries: Vec<ExamEntry> = Vec::new();
+
+        for e in &parsed {
             let date = e.exam_date.as_deref().and_then(parse_sap_date_str);
             let begin = e.exam_beg_time.as_deref().and_then(parse_sap_time);
             let end = e.exam_end_time.as_deref().and_then(parse_sap_time);
-            let key = (e.category_code.clone(), date.clone());
-            if seen.insert(key) {
-                result.push(Exam {
-                    category: e.category,
-                    category_code: e.category_code,
-                    date,
-                    begin_time: begin,
-                    end_time: end,
-                });
+            let note = e
+                .zz_se_comment
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+
+            let is_child = e
+                .zz_exam_offer_parent_guid
+                .as_deref()
+                .is_some_and(|p| !p.is_empty() && root_guids.contains(p));
+
+            // Child entries with "00:00 - 00:00" are effectively timeless.
+            let has_real_time = begin.as_deref().is_some_and(|b| b != "00:00")
+                || end.as_deref().is_some_and(|e| e != "00:00");
+
+            let (begin, end) = if is_child && !has_real_time {
+                (None, None)
+            } else {
+                (begin, end)
+            };
+
+            if has_real_time {
+                if let Some(ref d) = date {
+                    dates_with_time.insert((
+                        e.category_code.clone(),
+                        d.clone(),
+                        note.clone().unwrap_or_default(),
+                    ));
+                }
             }
+
+            entries.push(ExamEntry {
+                category: e.category.clone(),
+                category_code: e.category_code.clone(),
+                date,
+                begin_time: begin,
+                end_time: end,
+                note,
+                is_child,
+            });
+        }
+
+        // Deduplicate: suppress parent entries when a child with time exists.
+        let mut seen = HashSet::new();
+        let mut result = Vec::new();
+        for entry in entries {
+            // Skip root entries that have a child with time for the same date.
+            if !entry.is_child
+                && entry.begin_time.is_none()
+                && entry.date.as_ref().is_some_and(|d| {
+                    dates_with_time.contains(&(
+                        entry.category_code.clone(),
+                        d.clone(),
+                        entry.note.clone().unwrap_or_default(),
+                    ))
+                })
+            {
+                continue;
+            }
+
+            let dedup_key = (
+                entry.category_code.clone(),
+                entry.date.clone(),
+                entry.begin_time.clone(),
+                entry.end_time.clone(),
+                entry.note.clone(),
+            );
+            if !seen.insert(dedup_key) {
+                continue;
+            }
+
+            result.push(Exam {
+                category: entry.category,
+                category_code: entry.category_code,
+                date: entry.date,
+                begin_time: entry.begin_time,
+                end_time: entry.end_time,
+                note: entry.note,
+            });
         }
         result
     }
@@ -1259,71 +1630,222 @@ impl CachedSapClient {
 // Utility functions
 // ---------------------------------------------------------------------------
 
-/// Extract structured day/time from EventScheduleSet entries.
-/// Returns (day_of_week, start_time, end_time) from the first entry.
-fn extract_schedule_time(
-    entries: &RawScheduleEntries,
-) -> (Option<u8>, Option<String>, Option<String>) {
-    let Some(first) = entries.results.first() else {
-        return (None, None, None);
-    };
-
-    let day = first.evdat.as_deref().and_then(|d| {
-        let secs = parse_sap_date_epoch(d)?;
-        let dt = chrono::DateTime::from_timestamp(secs, 0)?;
-        // chrono: Mon=0 .. Sun=6. We want Sun=0, Mon=1, ..., Thu=4
-        let weekday = dt.weekday().num_days_from_sunday() as u8;
-        if weekday <= 4 {
-            Some(weekday)
-        } else {
-            None
-        }
-    });
-
-    let start_time = first.beguz.as_deref().and_then(parse_sap_time);
-    let end_time = first.enduz.as_deref().and_then(parse_sap_time);
-
-    (day, start_time, end_time)
+/// A single resolved time slot for a schedule event.
+#[derive(Debug, Clone)]
+struct ScheduleTimeSlot {
+    day: Option<u8>,
+    start_time: Option<String>,
+    end_time: Option<String>,
 }
 
-/// Resolve room text like "069-0001" into (building_name, room_number).
-fn resolve_room(room_text: &str) -> (Option<String>, Option<String>) {
-    // Room text format: "BBB-RRRR" where BBB = building code, RRRR = room number
-    let parts: Vec<&str> = room_text.split('-').collect();
-    if parts.len() != 2 {
-        return (None, Some(room_text.to_string()));
+/// Extract ALL structured day/time slots from EventScheduleSet entries.
+/// Groups identical (weekday, start, end) tuples and only keeps repeating ones
+/// (appearing more than half the expected number of sessions in a semester).
+/// This filters out one-off makeup sessions and keeps the regular weekly schedule.
+fn extract_all_schedule_times(entries: &RawScheduleEntries) -> Vec<ScheduleTimeSlot> {
+    if entries.results.is_empty() {
+        return vec![];
     }
-    let building_code = parts[0];
-    let room_number = parts[1].trim_start_matches('0');
-    let room_num = if room_number.is_empty() {
-        parts[1]
+
+    // Count occurrences of each (weekday, start, end) tuple.
+    type TimeKey = (Option<u8>, Option<String>, Option<String>);
+    let mut counts: HashMap<TimeKey, usize> = HashMap::new();
+
+    for entry in &entries.results {
+        let day = entry.evdat.as_deref().and_then(|d| {
+            let secs = parse_sap_date_epoch(d)?;
+            let dt = chrono::DateTime::from_timestamp(secs, 0)?;
+            let weekday = dt.weekday().num_days_from_sunday() as u8;
+            // Include Sun-Fri, skip Saturday.
+            if weekday <= 5 {
+                Some(weekday)
+            } else {
+                None
+            }
+        });
+
+        let start_time = entry.beguz.as_deref().and_then(parse_sap_time);
+        let end_time = entry.enduz.as_deref().and_then(parse_sap_time);
+
+        // Skip entries where day resolved to None (Saturday) but time exists.
+        if day.is_none() && start_time.is_some() {
+            continue;
+        }
+
+        *counts.entry((day, start_time, end_time)).or_insert(0) += 1;
+    }
+
+    // A regular semester has ~13 weeks, summer ~7. A repeating event should appear
+    // more than half that. Use half the average count as threshold.
+    let total_entries = entries.results.len();
+    let distinct_slots = counts.len().max(1);
+    let avg_count = total_entries / distinct_slots;
+    let min_repeating = avg_count / 2;
+
+    // If there's only one distinct slot, always keep it.
+    // Otherwise, filter to repeating ones.
+    let slots: Vec<ScheduleTimeSlot> = if distinct_slots == 1 {
+        counts
+            .into_keys()
+            .map(|(day, start_time, end_time)| ScheduleTimeSlot {
+                day,
+                start_time,
+                end_time,
+            })
+            .collect()
     } else {
-        room_number
+        counts
+            .into_iter()
+            .filter(|(_, count)| *count > min_repeating)
+            .map(|((day, start_time, end_time), _)| ScheduleTimeSlot {
+                day,
+                start_time,
+                end_time,
+            })
+            .collect()
     };
 
-    let building_name = match building_code {
+    slots
+}
+
+/// Detect buggy near-zero-duration schedule entries.
+/// Filters patterns like "01:01-01:02" or "00:0X-01:00".
+fn is_buggy_time_slot(slot: &ScheduleTimeSlot) -> bool {
+    let (Some(start), Some(end)) = (slot.start_time.as_deref(), slot.end_time.as_deref()) else {
+        return false;
+    };
+    // Parse "HH:MM" to minutes since midnight.
+    let parse_mins = |s: &str| -> Option<u32> {
+        let (h, m) = s.split_once(':')?;
+        Some(h.parse::<u32>().ok()? * 60 + m.parse::<u32>().ok()?)
+    };
+    let (Some(s), Some(e)) = (parse_mins(start), parse_mins(end)) else {
+        return false;
+    };
+    // Events shorter than 15 minutes are almost certainly data bugs.
+    e.saturating_sub(s) < 15
+}
+
+/// Resolve the display name for a sport course event.
+/// Sport courses have generic CategoryText ("ספורט" / "נבחרת ספורט") but
+/// the specific team name is in the EObject Name or SeObject (group) Name.
+fn resolve_sport_kind(
+    category_text: &str,
+    event_name: Option<&str>,
+    group_name_raw: &str,
+    course_id: &str,
+) -> String {
+    let event_name = event_name.unwrap_or("");
+
+    // If the event name is specific (not generic), use it.
+    let is_generic_event_name = event_name.is_empty()
+        || event_name.contains("ספורט חינוך גופני")
+        || event_name == "ספורט נבחרות ספורט"
+        || {
+            // Check if the name just ends with the course number.
+            let num = course_id.trim_start_matches('0');
+            let re = Regex::new(&format!(r"-\s*0*{}$", regex::escape(num))).unwrap();
+            re.is_match(event_name)
+        };
+
+    if !is_generic_event_name {
+        return event_name.to_string();
+    }
+
+    // Fall back to group-level name (strip "SE\d+" prefix).
+    if !group_name_raw.is_empty() {
+        let cleaned = Regex::new(r"^SE\d+\s*")
+            .unwrap()
+            .replace(group_name_raw, "")
+            .to_string();
+        if !cleaned.is_empty() {
+            return cleaned;
+        }
+    }
+
+    // Last resort: use the original category text.
+    category_text.to_string()
+}
+
+/// Static building code → name mapping. Comprehensive list matching
+/// the GObjectSet API results.
+/// When a code is missing, callers get None (still shows the room code).
+fn resolve_building_code(code: &str) -> Option<&'static str> {
+    // This list is derived from GObjectSet results + the SAP
+    // building names normalized the same way he does (strip "בנין"/"בניין" prefix).
+    match code {
         "014" => Some("טאוב"),
+        "015" => Some("אולם צ'רצ'יל"),
+        "016" => Some("הנ' כימית"),
+        "018" => Some("הנ' מכונות"),
+        "019" => Some("מתמטיקה"),
+        "020" => Some("כימיה"),
+        "021" => Some("פיסיקה"),
+        "024" => Some("הנ' תעשיה"),
+        "025" => Some("הנ' חשמל"),
+        "028" => Some("ביולוגיה"),
+        "030" => Some("גולדשטיין-גורן"),
         "032" => Some("אמדו"),
+        "033" => Some("מדעי המזון"),
         "034" => Some("זיסאפל"),
         "037" => Some("ליידי דייוס"),
+        "038" => Some("אודיטוריום"),
+        "039" => Some("ארכיטקטורה"),
+        "040" => Some("ביוטכנולוגיה"),
         "044" => Some("פישבך"),
+        "048" => Some("הנ' ביורפואית"),
         "054" => Some("אולמן"),
+        "056" => Some("מדע החלטות"),
         "058" => Some("סגו"),
+        "060" => Some("ביוטכנולוגיה ומדעי המזון"),
         "069" => Some("דן קהאן"),
+        "071" => Some("ספריה מרכזית"),
         "079" => Some("הנדסת חמרים"),
         "084" => Some("מדעי המחשב"),
+        "088" => Some("אהרונוב"),
+        "090" => Some("מכון נאמן"),
         "093" => Some("בורוביץ הנדסה אזרחית"),
         "095" => Some("הנ' אוירונאוטית"),
+        "096" => Some("רקנאטי"),
         "102" => Some("פקולטה לרפואה"),
         "103" => Some("ננו-אלקטרוניקה"),
         "120" => Some("ספורט"),
+        "121" => Some("בנין ספורט 2"),
+        "126" => Some("מגרש כדורגל"),
+        "127" => Some("מגרש טניס"),
+        "128" => Some("בריכת שחיה"),
+        "129" => Some("סקווש"),
         _ => None,
-    };
+    }
+}
 
-    (
-        building_name.map(|s| s.to_string()),
-        Some(room_num.to_string()),
-    )
+/// Normalize a building name from GObjectSet (e.g. "בנין ע'ש טאוב" → "טאוב").
+/// Matches the normalization used by GObjectSet building names.
+fn normalize_building_name(raw: &str) -> String {
+    let trimmed = Regex::new(r"\s+").unwrap().replace_all(raw.trim(), " ");
+    let mappings: &[(&str, &str)] = &[
+        ("בנין אולמן", "אולמן"),
+        ("בנין בורוביץ הנדסה אזרחית", "בורוביץ הנדסה אזרחית"),
+        ("בנין דן קהאן", "דן קהאן"),
+        ("בנין הנ' אוירונאוטית", "הנ' אוירונאוטית"),
+        ("בנין זיסאפל", "זיסאפל"),
+        ("בנין להנדסת חמרים", "הנדסת חמרים"),
+        ("בנין ליידי דייוס", "ליידי דייוס"),
+        ("בנין למדעי המחשב", "מדעי המחשב"),
+        ("בנין ע'ש אמדו", "אמדו"),
+        ("בנין ע'ש טאוב", "טאוב"),
+        ("בנין ע'ש סגו", "סגו"),
+        ("בנין פישבך", "פישבך"),
+        ("בנין פקולטה לרפואה", "פקולטה לרפואה"),
+        ("בניין ננו-אלקטרוניקה", "ננו-אלקטרוניקה"),
+        ("בניין ספורט", "ספורט"),
+    ];
+    for (prefix, replacement) in mappings {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            return format!("{replacement}{rest}");
+        }
+    }
+    trimmed.to_string()
 }
 
 fn format_person(persons: &[RawPerson]) -> Option<String> {
@@ -1338,7 +1860,7 @@ fn format_person(persons: &[RawPerson]) -> Option<String> {
 }
 
 /// Parse corequisites from semester notes. Looks for lines like:
-/// "מקצוע צמוד: 104031" or "מקצועות צמודים: 104031, 104166"
+/// "מקצוע צמוד: 01040031" or "מקצועות צמודים: 01040031, 01041066"
 fn parse_corequisites(note: &str) -> Vec<String> {
     let re = Regex::new(r"מקצועו?ת? צמודי?ם?:\s*(.+)").unwrap();
     let Some(caps) = re.captures(note) else {
@@ -1348,47 +1870,20 @@ fn parse_corequisites(note: &str) -> Vec<String> {
     let num_re = Regex::new(r"\d{5,8}").unwrap();
     num_re
         .find_iter(content)
-        .map(|m| {
-            let n = m.as_str();
-            if n.len() <= 6 {
-                to_new_course_number(&format!("{n:0>6}"))
-            } else {
-                n.to_string()
-            }
-        })
+        .map(|m| format!("{:0>8}", m.as_str()))
         .collect()
 }
 
-/// Convert a 6-digit Technion course number to the SAP `SM` ID format.
+/// Prepend `SM` to get the SAP OData entity ID.
+/// Course numbers are always 8-digit (e.g. "02340114").
 pub fn course_number_to_sap_id(number: &str) -> String {
-    let padded = format!("{number:0>6}");
-    // Special case: 9730XX → 970300XX
-    if let Some(suffix) = padded.strip_prefix("9730") {
-        return format!("SM970300{suffix}");
-    }
-    format!("SM0{}0{}", &padded[..3], &padded[3..])
+    format!("SM{number}")
 }
 
-/// Extract the 6-digit course number from a SAP ID.
+/// Strip the `SM` prefix from a SAP OData entity ID.
+/// Returns the 8-digit course number (e.g. "02340114").
 pub fn sap_id_to_course_number(sap_id: &str) -> String {
-    let digits = sap_id.trim_start_matches("SM");
-    if digits.len() == 8 {
-        // Check for 970300XX → 9730XX
-        if let Some(suffix) = digits.strip_prefix("970300") {
-            return format!("9730{suffix}");
-        }
-        format!("{}{}", &digits[1..4], &digits[5..8])
-    } else {
-        digits.to_string()
-    }
-}
-
-/// Normalize old course numbers to the new 8-digit format (used for corequisites).
-fn to_new_course_number(course: &str) -> String {
-    if course.starts_with("9730") && course.len() == 6 {
-        return format!("970300{}", &course[4..]);
-    }
-    course.to_string()
+    sap_id.trim_start_matches("SM").to_string()
 }
 
 fn parse_sap_date_epoch(date_str: &str) -> Option<i64> {
@@ -1421,11 +1916,92 @@ mod tests {
 
     #[test]
     fn test_course_number_conversions() {
-        assert_eq!(course_number_to_sap_id("234114"), "SM02340114");
-        assert_eq!(course_number_to_sap_id("104031"), "SM01040031");
-        assert_eq!(course_number_to_sap_id("973012"), "SM97030012");
-        assert_eq!(sap_id_to_course_number("SM02340114"), "234114");
-        assert_eq!(sap_id_to_course_number("SM97030012"), "973012");
+        assert_eq!(course_number_to_sap_id("02340114"), "SM02340114");
+        assert_eq!(course_number_to_sap_id("01040031"), "SM01040031");
+        assert_eq!(sap_id_to_course_number("SM02340114"), "02340114");
+        assert_eq!(sap_id_to_course_number("SM97030012"), "97030012");
+    }
+
+    #[test]
+    fn test_is_sport_course() {
+        assert!(is_sport_course("03940902")); // נבחרות ספורט
+        assert!(is_sport_course("03940800")); // חינוך גופני
+        assert!(is_sport_course("03940999"));
+        assert!(!is_sport_course("03940700")); // not sport range
+        assert!(!is_sport_course("02340114")); // מבוא למדמ"ח
+        assert!(!is_sport_course("01040031")); // infi 1
+    }
+
+    #[test]
+    fn test_classify_malag() {
+        let h = Some(HUMANITIES_FACULTY);
+
+        // Standard malag courses
+        assert!(classify_malag(
+            "03240879",
+            "סוגיות נבחרות בחברה הישראלית",
+            2.0,
+            h
+        ));
+        assert!(classify_malag("03240442", "משפט העבודה בישראל", 2.0, h));
+        assert!(classify_malag("03250010", "מדע דת ופילוסופיה", 2.0, h));
+        assert!(classify_malag(
+            "03260005",
+            "פריצות דרך בתולדות החשיבה המתמטית",
+            2.0,
+            h
+        ));
+
+        // Explicit non-humanities malags
+        assert!(classify_malag(
+            "02140120",
+            "יסודות למידה והוראה",
+            2.0,
+            Some("חינוך למדע וטכנולוגיה")
+        ));
+        assert!(classify_malag(
+            "02750112",
+            "אבולוציה של האדם",
+            2.0,
+            Some("הפקולטה לרפואה")
+        ));
+
+        // Language courses — not malag
+        assert!(!classify_malag("03240692", "סינית למתחילים", 2.0, h));
+        assert!(!classify_malag("03240600", "גרמנית 1", 2.0, h));
+        assert!(!classify_malag("03240685", "שיחה באנגלית למתקדמים", 2.0, h));
+
+        // Art/performance — not malag
+        assert!(!classify_malag("03240481", "רישום למתחילים", 2.0, h));
+        assert!(!classify_malag("03240236", "תזמורת נשיפה", 2.0, h));
+
+        // Academic writing — not malag
+        assert!(!classify_malag(
+            "03240490",
+            "כתיבה אקדמית לתואר ראשון",
+            2.0,
+            h
+        ));
+
+        // Wrong credits — not malag
+        assert!(!classify_malag(
+            "03240033",
+            "אנגלית טכנית-מתקדמים ב'",
+            3.0,
+            h
+        ));
+        assert!(!classify_malag("03240513", "מחזה-הצגה-מופע", 1.5, h));
+
+        // Wrong faculty — not malag
+        assert!(!classify_malag(
+            "02340114",
+            "מבוא למדעי המחשב",
+            2.0,
+            Some("הנדסת חשמל ומחשבים")
+        ));
+
+        // Sport — not malag
+        assert!(!classify_malag("03940902", "נבחרות ספורט", 1.5, h));
     }
 
     #[test]
@@ -1440,10 +2016,10 @@ mod tests {
 
     #[test]
     fn test_parse_corequisites() {
-        assert_eq!(parse_corequisites("מקצוע צמוד: 104031"), vec!["104031"]);
+        assert_eq!(parse_corequisites("מקצוע צמוד: 104031"), vec!["00104031"]);
         assert_eq!(
             parse_corequisites("מקצועות צמודים: 104031, 104166"),
-            vec!["104031", "104166"]
+            vec!["00104031", "00104166"]
         );
         assert_eq!(parse_corequisites("no coreqs here"), Vec::<String>::new());
     }
@@ -1480,7 +2056,7 @@ mod tests {
         let s = &semesters[0];
         let ids = client().get_course_ids(&s.year, &s.semester).await.unwrap();
         assert!(ids.len() > 100);
-        // IDs should be 6-digit course numbers, not SAP format
+        // IDs should be 8-digit course numbers without SM prefix
         assert!(ids.iter().all(|id| !id.starts_with("SM")));
     }
 
@@ -1490,9 +2066,12 @@ mod tests {
         let c = client();
 
         // First fetch — hits SAP
-        let d1 = c.get_course_details("2025", "200", "234114").await.unwrap();
+        let d1 = c
+            .get_course_details("2025", "200", "02340114")
+            .await
+            .unwrap();
         assert_eq!(d1.name, "מבוא למדעי המחשב מ'");
-        assert_eq!(d1.id, "234114");
+        assert_eq!(d1.id, "02340114");
         assert!(d1.credits > 0.0);
         assert!(!d1.exams.is_empty());
         assert!(d1.exams.len() < 10); // deduped
@@ -1501,12 +2080,15 @@ mod tests {
         assert!(!d1.offered_periods.is_empty());
 
         // Second fetch — should be instant (cached)
-        let d2 = c.get_course_details("2025", "200", "234114").await.unwrap();
+        let d2 = c
+            .get_course_details("2025", "200", "02340114")
+            .await
+            .unwrap();
         assert!(Arc::ptr_eq(&d1, &d2)); // same Arc = same cache entry
 
         // Verify JSON serialization works
         let json = serde_json::to_string_pretty(&*d1).unwrap();
-        assert!(json.contains("234114"));
+        assert!(json.contains("02340114"));
         assert!(json.contains("מבוא למדעי המחשב"));
         println!("{json}");
     }

--- a/packages/sogrim-app-v2/bun.lock
+++ b/packages/sogrim-app-v2/bun.lock
@@ -9,6 +9,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-router": "^1.166.6",
         "ag-grid-community": "^35.1.0",
@@ -154,6 +155,14 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
@@ -178,6 +187,8 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
@@ -194,6 +205,8 @@
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
 
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
@@ -204,6 +217,8 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
+
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
     "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
@@ -213,6 +228,14 @@
     "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -729,6 +752,8 @@
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 

--- a/packages/sogrim-app-v2/src/components/planner/add-course-form.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/add-course-form.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Plus, X, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Dropdown } from "@/components/ui/dropdown";
 import { Toast } from "@/components/ui/toast";
 import { useCoursesFilter } from "@/hooks/use-courses-filter";
 import { courseFromUserValidations } from "@/lib/course-validator";
@@ -194,20 +195,13 @@ export function AddCourseForm({
             ציון
           </label>
           {isSemester0 ? (
-            <select
+            <Dropdown
               value={grade}
-              onChange={(e) => setGrade(e.target.value)}
-              className="w-full h-8 rounded border border-border bg-card px-1 text-sm focus:outline-none focus:ring-1 focus:ring-foreground/30"
-            >
-              <option value="">--</option>
-              {COURSE_GRADE_OPTIONS.filter((opt) =>
+              onChange={setGrade}
+              options={COURSE_GRADE_OPTIONS.filter((opt) =>
                 opt.includes("פטור")
-              ).map((opt) => (
-                <option key={opt} value={opt}>
-                  {opt}
-                </option>
-              ))}
-            </select>
+              ).map((opt) => ({ value: opt, label: opt }))}
+            />
           ) : gradeIsNumeric ? (
             <div className="space-y-0.5">
               <input
@@ -229,18 +223,11 @@ export function AddCourseForm({
             </div>
           ) : (
             <div className="space-y-0.5">
-              <select
+              <Dropdown
                 value={grade}
-                onChange={(e) => setGrade(e.target.value)}
-                className="w-full h-8 rounded border border-border bg-card px-1 text-sm focus:outline-none focus:ring-1 focus:ring-foreground/30"
-              >
-                <option value="">--</option>
-                {COURSE_GRADE_OPTIONS.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
+                onChange={setGrade}
+                options={COURSE_GRADE_OPTIONS.map((opt) => ({ value: opt, label: opt }))}
+              />
               <button
                 type="button"
                 onClick={() => { setGradeIsNumeric(true); setGrade(""); }}
@@ -258,18 +245,12 @@ export function AddCourseForm({
             <label className="text-[11px] text-muted-foreground mb-0.5 block">
               קטגוריה
             </label>
-            <select
+            <Dropdown
               value={type}
-              onChange={(e) => setType(e.target.value)}
-              className="w-full h-8 rounded border border-border bg-card px-1 text-sm focus:outline-none focus:ring-1 focus:ring-foreground/30"
-            >
-              <option value="">--</option>
-              {bankNames.map((name) => (
-                <option key={name} value={name}>
-                  {name}
-                </option>
-              ))}
-            </select>
+              onChange={setType}
+              options={bankNames.map((name) => ({ value: name, label: name }))}
+              placeholder="--"
+            />
           </div>
         )}
 

--- a/packages/sogrim-app-v2/src/components/planner/planner-course-search.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/planner-course-search.tsx
@@ -6,6 +6,7 @@ import type { CourseSchedule } from "@/types/timetable";
 import type { RowData } from "@/types/domain";
 import { Plus, X, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Dropdown } from "@/components/ui/dropdown";
 import { Toast } from "@/components/ui/toast";
 
 interface PlannerCourseSearchProps {
@@ -144,20 +145,13 @@ export function PlannerCourseSearch({
             ציון
           </label>
           {isSemester0 ? (
-            <select
+            <Dropdown
               value={grade}
-              onChange={(e) => setGrade(e.target.value)}
-              className="w-full h-8 rounded border border-border bg-card px-1 text-sm focus:outline-none focus:ring-1 focus:ring-foreground/30"
-            >
-              <option value="">--</option>
-              {COURSE_GRADE_OPTIONS.filter((opt) =>
+              onChange={setGrade}
+              options={COURSE_GRADE_OPTIONS.filter((opt) =>
                 opt.includes("פטור")
-              ).map((opt) => (
-                <option key={opt} value={opt}>
-                  {opt}
-                </option>
-              ))}
-            </select>
+              ).map((opt) => ({ value: opt, label: opt }))}
+            />
           ) : gradeIsNumeric ? (
             <div className="space-y-0.5">
               <input
@@ -179,18 +173,11 @@ export function PlannerCourseSearch({
             </div>
           ) : (
             <div className="space-y-0.5">
-              <select
+              <Dropdown
                 value={grade}
-                onChange={(e) => setGrade(e.target.value)}
-                className="w-full h-8 rounded border border-border bg-card px-1 text-sm focus:outline-none focus:ring-1 focus:ring-foreground/30"
-              >
-                <option value="">--</option>
-                {COURSE_GRADE_OPTIONS.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
+                onChange={setGrade}
+                options={COURSE_GRADE_OPTIONS.map((opt) => ({ value: opt, label: opt }))}
+              />
               <button
                 type="button"
                 onClick={() => { setGradeIsNumeric(true); setGrade(""); }}
@@ -208,18 +195,12 @@ export function PlannerCourseSearch({
             <label className="text-[11px] text-muted-foreground mb-0.5 block">
               קטגוריה
             </label>
-            <select
+            <Dropdown
               value={type}
-              onChange={(e) => setType(e.target.value)}
-              className="w-full h-8 rounded border border-border bg-card px-1 text-sm focus:outline-none focus:ring-1 focus:ring-foreground/30"
-            >
-              <option value="">--</option>
-              {bankNames.map((name) => (
-                <option key={name} value={name}>
-                  {name}
-                </option>
-              ))}
-            </select>
+              onChange={setType}
+              options={bankNames.map((name) => ({ value: name, label: name }))}
+              placeholder="--"
+            />
           </div>
         )}
 

--- a/packages/sogrim-app-v2/src/components/settings/settings-page.tsx
+++ b/packages/sogrim-app-v2/src/components/settings/settings-page.tsx
@@ -32,7 +32,8 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Select } from "@/components/ui/select";
+import { Combobox } from "@/components/ui/combobox";
+import type { ComboboxOption } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
@@ -83,13 +84,8 @@ export function SettingsPage() {
 
   const currentCatalogId = userState?.details?.catalog?._id?.$oid;
 
-  function handleCatalogChange(
-    e: React.ChangeEvent<HTMLSelectElement>
-  ) {
-    const catalogId = e.target.value;
+  function handleCatalogChange(catalogId: string) {
     if (!catalogId || catalogId === currentCatalogId) return;
-
-    // Show warning before changing catalog
     setPendingCatalogId(catalogId);
     setShowCatalogWarning(true);
   }
@@ -264,34 +260,23 @@ export function SettingsPage() {
             <>
               <div className="space-y-2">
                 <Label htmlFor="catalog-select">מסלול לימודים</Label>
-                <Select
+                <Combobox
                   id="catalog-select"
                   value={currentCatalogId || ""}
                   onChange={handleCatalogChange}
                   disabled={updateCatalog.isPending}
-                >
-                  <option value="" disabled>
-                    בחר קטלוג...
-                  </option>
-                  {Object.entries(grouped).map(
-                    ([faculty, facultyCatalogs]) => (
-                      <optgroup
-                        key={faculty}
-                        label={FACULTY_LABELS[faculty] || faculty}
-                      >
-                        {facultyCatalogs.map((catalog) => (
-                          <option
-                            key={catalog._id.$oid}
-                            value={catalog._id.$oid}
-                          >
-                            {catalog.name} ({catalog.total_credit}{" "}
-                            נ״ז)
-                          </option>
-                        ))}
-                      </optgroup>
-                    )
+                  placeholder="בחר קטלוג..."
+                  searchPlaceholder="חיפוש מסלול או שנה..."
+                  emptyMessage="לא נמצאו מסלולים"
+                  options={Object.entries(grouped).flatMap(
+                    ([faculty, facultyCatalogs]): ComboboxOption[] =>
+                      facultyCatalogs.map((catalog) => ({
+                        value: catalog._id.$oid,
+                        label: `${catalog.name} (${catalog.total_credit} נ״ז)`,
+                        group: FACULTY_LABELS[faculty] || faculty,
+                      }))
                   )}
-                </Select>
+                />
               </div>
 
               {/* Catalog change warning */}

--- a/packages/sogrim-app-v2/src/components/timetable/course-block.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/course-block.tsx
@@ -30,7 +30,7 @@ export function CourseBlock({ event, compact = false, onCustomEventClick }: Cour
   }, [event.colorIndex, event.isCustom, event.customColor, isDark]);
 
   const typeLabel = LESSON_TYPE_NAMES[event.type];
-  const groupNum = event.groupId.split("-")[0];
+  const groupNum = event.groupId.split("-")[0].replace(/^0+/, "") || "0";
   const location =
     [event.building, event.room].filter(Boolean).join(" ") || undefined;
 
@@ -50,18 +50,19 @@ export function CourseBlock({ event, compact = false, onCustomEventClick }: Cour
     <div
       onClick={handleClick}
       className={cn(
-        "rounded-md cursor-pointer h-full overflow-hidden",
-        "flex flex-col items-center justify-center text-center",
-        "transition-all duration-150 px-1",
+        "rounded-sm cursor-pointer h-full overflow-hidden",
+        "flex flex-col items-start justify-start text-start",
+        "transition-all duration-150 p-0.5",
         isPreview
-          ? "border-2 hover:border-[3px]"
-          : "border-2 hover:brightness-95 dark:hover:brightness-110",
+          ? "border hover:border-2"
+          : "border hover:brightness-95 dark:hover:brightness-110",
         event.isCustom && "border-dashed",
         event.hasConflict && "ring-2 ring-destructive ring-offset-1 dark:ring-offset-background",
       )}
       style={{
         ...style,
-        fontSize: compact ? "calc(0.05em + 1vh)" : "calc(0.1em + 1.3vh)",
+        fontSize: compact ? "calc(0.05em + 0.9vh)" : "calc(0.1em + 1.1vh)",
+        lineHeight: 1.2,
         backgroundColor: isPreview
           ? (isDark ? "rgba(0,0,0,0.15)" : "rgba(255,255,255,0.85)")
           : "var(--course-bg)",
@@ -77,23 +78,28 @@ export function CourseBlock({ event, compact = false, onCustomEventClick }: Cour
       ].filter(Boolean).join(" · ")}
     >
       {event.isCustom && !compact && (
-        <Star className="absolute top-1 left-1 h-2.5 w-2.5 opacity-60" />
+        <Star className="absolute top-0.5 left-0.5 h-2 w-2 opacity-60" />
       )}
 
-      {/* Course name */}
-      <div className="font-bold leading-tight w-full">
-        {event.courseName}
-      </div>
+      {!event.isCustom ? (
+        <>
+          {/* Line 1: type + group number (e.g. "הרצאה 11" or "נבחרת טניס נשים 17") */}
+          <div className="font-bold w-full break-words">
+            {event.courseName} {groupNum}
+          </div>
 
-      {/* Metadata: type+group, building, instructor */}
-      {!event.isCustom && (
-        <div className={cn(
-          "leading-tight w-full",
-          isPreview ? "font-medium" : "opacity-90",
-        )} style={{ fontSize: "0.85em" }}>
-          <div>{typeLabel} {groupNum}</div>
-          {location && <div>{location}</div>}
-          {event.instructor && <div>{event.instructor}</div>}
+          {/* Line 2+: building+room, instructor */}
+          <div className={cn(
+            "w-full break-words",
+            isPreview ? "font-medium" : "opacity-90",
+          )} style={{ fontSize: "0.85em" }}>
+            {location && <div>{location}</div>}
+            {event.instructor && <div>{event.instructor}</div>}
+          </div>
+        </>
+      ) : (
+        <div className="font-bold w-full break-words">
+          {event.courseName}
         </div>
       )}
     </div>

--- a/packages/sogrim-app-v2/src/components/timetable/semester-selector.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/semester-selector.tsx
@@ -1,7 +1,7 @@
 import { useTimetableStore } from "@/stores/timetable-store";
 import { getProvider } from "@/data/course-schedule-provider";
 import { switchProviderSemester } from "@/hooks/use-api-provider";
-import { cn } from "@/lib/utils";
+import { Dropdown } from "@/components/ui/dropdown";
 
 export function SemesterSelector() {
   const currentSemester = useTimetableStore((s) => s.currentSemester);
@@ -15,24 +15,17 @@ export function SemesterSelector() {
   }
 
   return (
-    <select
+    <Dropdown
       value={currentSemester}
-      onChange={(e) => {
-        setSemester(e.target.value);
-        switchProviderSemester(e.target.value);
+      onChange={(value) => {
+        setSemester(value);
+        switchProviderSemester(value);
       }}
-      className={cn(
-        "bg-secondary text-foreground rounded-lg px-3 py-1.5 text-sm font-medium",
-        "border border-border cursor-pointer",
-        "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
-      )}
-      dir="rtl"
-    >
-      {semesters.map((sem) => (
-        <option key={sem.id} value={sem.id}>
-          {sem.name}
-        </option>
-      ))}
-    </select>
+      options={semesters.map((sem) => ({
+        value: sem.id,
+        label: sem.name,
+      }))}
+      className="w-40"
+    />
   );
 }

--- a/packages/sogrim-app-v2/src/components/timetable/week-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/week-grid.tsx
@@ -2,14 +2,17 @@ import { useMemo, useState, useCallback, useRef } from "react";
 import type { Day, TimetableEvent } from "@/types/timetable";
 import {
   DAY_NAMES,
-  DAYS,
+  WEEKDAYS,
   DEFAULT_START_HOUR,
   DEFAULT_END_HOUR,
+  SLOT_MINUTES,
   getTimeLabels,
   totalSlots,
   computeVisibleRange,
   timeToRow,
   timeSpanRows,
+  parseTime,
+  hasFridayEvents,
 } from "@/lib/timetable-utils";
 import { CourseBlock } from "./course-block";
 import { CustomEventDialog } from "./custom-event-dialog";
@@ -21,13 +24,18 @@ interface WeekGridProps {
 }
 
 export function WeekGrid({ events, compact = false }: WeekGridProps) {
-  // Only expand the visible range, never shrink — prevents grid jumps.
-  // This prevents grid jumps when previews appear/disappear.
-  const rangeRef = useRef({ startHour: DEFAULT_START_HOUR, endHour: DEFAULT_END_HOUR });
-  const computed = computeVisibleRange(events);
-  if (computed.startHour < rangeRef.current.startHour) rangeRef.current.startHour = computed.startHour;
-  if (computed.endHour > rangeRef.current.endHour) rangeRef.current.endHour = computed.endHour;
-  const { startHour, endHour } = rangeRef.current;
+  // Show Friday column only when there are Friday events.
+  const showFriday = useMemo(() => hasFridayEvents(events), [events]);
+  const visibleDays = useMemo(() => showFriday ? [...WEEKDAYS, 5 as Day] : WEEKDAYS, [showFriday]);
+  const dayCount = visibleDays.length;
+
+  // Base range from real (non-preview) events — snaps back when courses are removed.
+  // Preview events can temporarily expand the range but don't persist.
+  const realEvents = useMemo(() => events.filter((e) => !e.isPreview), [events]);
+  const baseRange = useMemo(() => computeVisibleRange(realEvents), [realEvents]);
+  const fullRange = computeVisibleRange(events);
+  const startHour = Math.min(baseRange.startHour, fullRange.startHour);
+  const endHour = Math.max(baseRange.endHour, fullRange.endHour);
   const slotCount = totalSlots(startHour, endHour);
   const timeLabels = useMemo(() => getTimeLabels(startHour, endHour), [startHour, endHour]);
   const [customDialog, setCustomDialog] = useState<{
@@ -49,11 +57,11 @@ export function WeekGrid({ events, compact = false }: WeekGridProps) {
 
   const eventsByDay = useMemo(() => {
     const map = new Map<Day, TimetableEvent[]>();
-    for (const day of DAYS) {
+    for (const day of visibleDays) {
       map.set(day, events.filter((e) => e.day === day));
     }
     return map;
-  }, [events]);
+  }, [events, visibleDays]);
 
   const handleDragStart = useCallback((day: Day, row: number) => {
     setDragState({ active: true, day, startRow: row, currentRow: row });
@@ -104,15 +112,15 @@ export function WeekGrid({ events, compact = false }: WeekGridProps) {
           className="grid min-w-0"
           style={{
             gridTemplateColumns: compact
-              ? "36px repeat(5, 1fr)"
-              : "56px repeat(5, 1fr)",
+              ? `36px repeat(${dayCount}, 1fr)`
+              : `56px repeat(${dayCount}, 1fr)`,
             gridTemplateRows: `auto repeat(${slotCount}, minmax(${compact ? "2.5vh" : "4.2vh"}, 1fr))`,
           }}
           dir="rtl"
         >
           {/* Header row */}
           <div className="sticky top-0 z-10 bg-card border-b border-border" />
-          {DAYS.map((day) => (
+          {visibleDays.map((day) => (
             <div
               key={day}
               className={cn(
@@ -125,26 +133,30 @@ export function WeekGrid({ events, compact = false }: WeekGridProps) {
             </div>
           ))}
 
-          {/* Time labels */}
-          {timeLabels.map((label, i) => (
-            <div
-              key={label}
-              className={cn(
-                "border-t border-border/50 flex items-start justify-center",
-                "text-muted-foreground pt-0.5",
-                compact ? "text-[0.55rem]" : "text-xs",
-              )}
-              style={{
-                gridRow: `${i * 2 + 2} / span 2`,
-                gridColumn: 1,
-              }}
-            >
-              {label}
-            </div>
-          ))}
+          {/* Time labels — one per hour, each spanning 2 grid rows */}
+          {timeLabels.map((label) => {
+            const labelMinutes = parseTime(label);
+            const row = Math.round((labelMinutes - startHour * 60) / SLOT_MINUTES);
+            return (
+              <div
+                key={label}
+                className={cn(
+                  "border-t border-border/50 flex items-start justify-center",
+                  "text-muted-foreground pt-0.5",
+                  compact ? "text-[0.55rem]" : "text-xs",
+                )}
+                style={{
+                  gridRow: `${row + 2} / span 2`,
+                  gridColumn: 1,
+                }}
+              >
+                {label}
+              </div>
+            );
+          })}
 
           {/* Day columns */}
-          {DAYS.map((day) => (
+          {visibleDays.map((day, idx) => (
             <DayColumn
               key={day}
               day={day}
@@ -157,6 +169,7 @@ export function WeekGrid({ events, compact = false }: WeekGridProps) {
               onDragEnd={handleDragEnd}
               onCustomEventClick={handleCustomEventClick}
               dragState={dragState?.day === day ? dragState : null}
+              colIndex={idx}
             />
           ))}
         </div>
@@ -175,6 +188,75 @@ export function WeekGrid({ events, compact = false }: WeekGridProps) {
   );
 }
 
+/** Lay out events into non-overlapping columns (like FullCalendar's slotEventOverlap:false).
+ *  Returns positioned events with left/width percentages within the column. */
+function layoutEvents(
+  events: TimetableEvent[],
+  startHour: number,
+  slotCount: number,
+): { event: TimetableEvent; topPct: number; heightPct: number; leftPct: number; widthPct: number }[] {
+  if (events.length === 0) return [];
+
+  // Sort by start time, then by duration (longer first for stable layout).
+  const sorted = [...events].sort((a, b) => {
+    const aStart = parseTime(a.startTime);
+    const bStart = parseTime(b.startTime);
+    if (aStart !== bStart) return aStart - bStart;
+    return parseTime(b.endTime) - parseTime(a.endTime);
+  });
+
+  // Assign each event to a column, tracking end times per column.
+  const columns: number[] = []; // end time (in minutes) of each column
+  const eventCols: number[] = [];
+  const eventGroups: number[] = []; // which overlap group each event belongs to
+  const groupMaxCols: number[] = []; // max columns used per group
+
+  let currentGroupStart = 0;
+  let currentGroupEnd = 0;
+  let groupIndex = -1;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const ev = sorted[i];
+    const evStart = parseTime(ev.startTime);
+    const evEnd = parseTime(ev.endTime);
+
+    // Check if this event starts a new non-overlapping group
+    if (evStart >= currentGroupEnd) {
+      groupIndex++;
+      currentGroupStart = evStart;
+      currentGroupEnd = evEnd;
+      columns.length = 0; // reset columns for new group
+    } else {
+      currentGroupEnd = Math.max(currentGroupEnd, evEnd);
+    }
+
+    // Find first column where the event fits (no overlap)
+    let col = 0;
+    while (col < columns.length && columns[col] > evStart) {
+      col++;
+    }
+    columns[col] = evEnd;
+    eventCols[i] = col;
+    eventGroups[i] = groupIndex;
+    groupMaxCols[groupIndex] = Math.max(groupMaxCols[groupIndex] ?? 0, col + 1);
+  }
+
+  return sorted.map((event, i) => {
+    const row = timeToRow(event.startTime, startHour);
+    const span = timeSpanRows(event.startTime, event.endTime);
+    const totalCols = groupMaxCols[eventGroups[i]];
+    const col = eventCols[i];
+
+    return {
+      event,
+      topPct: (row / slotCount) * 100,
+      heightPct: (span / slotCount) * 100,
+      leftPct: (col / totalCols) * 100,
+      widthPct: (1 / totalCols) * 100,
+    };
+  });
+}
+
 interface DayColumnProps {
   day: Day;
   events: TimetableEvent[];
@@ -186,6 +268,8 @@ interface DayColumnProps {
   onDragEnd: () => void;
   onCustomEventClick: (eventId: string) => void;
   dragState: { startRow: number; currentRow: number } | null;
+  /** 0-based index within the visible day columns */
+  colIndex: number;
 }
 
 function DayColumn({
@@ -199,8 +283,9 @@ function DayColumn({
   onDragEnd,
   onCustomEventClick,
   dragState,
+  colIndex,
 }: DayColumnProps) {
-  const dayCol = day + 2;
+  const dayCol = colIndex + 2; // +1 for 1-based grid, +1 for time label column
   const colRef = useRef<HTMLDivElement>(null);
 
   const getRowFromY = (clientY: number): number => {
@@ -249,12 +334,12 @@ function DayColumn({
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
     >
-      {/* Background grid lines */}
-      {Array.from({ length: slotCount / 2 }, (_, i) => (
+      {/* Background grid lines — every hour (2 slots) */}
+      {Array.from({ length: Math.floor(slotCount / 2) }, (_, i) => (
         <div
           key={i}
           className="absolute inset-x-0 border-t border-border/30 pointer-events-none"
-          style={{ top: `${(i * 2 / slotCount) * 100}%` }}
+          style={{ top: `${((i * 2) / slotCount) * 100}%` }}
         />
       ))}
 
@@ -266,31 +351,26 @@ function DayColumn({
         />
       )}
 
-      {/* Course blocks — absolutely positioned */}
-      {events.map((event) => {
-        const row = timeToRow(event.startTime, startHour);
-        const span = timeSpanRows(event.startTime, event.endTime);
-        const topPct = (row / slotCount) * 100;
-        const heightPct = (span / slotCount) * 100;
-
-        return (
-          <div
-            key={`${event.courseId}-${event.groupId}-${event.startTime}-${event.isPreview}`}
-            className="absolute inset-x-0.5 z-[2]"
-            style={{
-              top: `${topPct}%`,
-              height: `${heightPct}%`,
-            }}
-            onMouseDown={(e) => e.stopPropagation()}
-          >
-            <CourseBlock
-              event={event}
-              compact={compact}
-              onCustomEventClick={onCustomEventClick}
-            />
-          </div>
-        );
-      })}
+      {/* Course blocks — absolutely positioned, with column layout for overlaps */}
+      {layoutEvents(events, startHour, slotCount).map(({ event, topPct, heightPct, leftPct, widthPct }) => (
+        <div
+          key={`${event.courseId}-${event.groupId}-${event.startTime}-${event.isPreview}`}
+          className="absolute z-[2]"
+          style={{
+            top: `${topPct}%`,
+            height: `${heightPct}%`,
+            right: `${leftPct}%`,
+            width: `${widthPct}%`,
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <CourseBlock
+            event={event}
+            compact={compact}
+            onCustomEventClick={onCustomEventClick}
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/sogrim-app-v2/src/components/ui/combobox.tsx
+++ b/packages/sogrim-app-v2/src/components/ui/combobox.tsx
@@ -1,0 +1,136 @@
+import { useState, useRef, useEffect } from "react";
+import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from "./command";
+import { ChevronDown, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  group?: string;
+}
+
+interface ComboboxProps {
+  options: ComboboxOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+export function Combobox({
+  options,
+  value,
+  onChange,
+  placeholder = "בחר...",
+  searchPlaceholder = "חיפוש...",
+  emptyMessage = "לא נמצאו תוצאות",
+  disabled = false,
+  className,
+  id,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, [open]);
+
+  // Group options if any have a group field
+  const hasGroups = options.some((o) => o.group);
+  const groups: Map<string, ComboboxOption[]> = new Map();
+  if (hasGroups) {
+    for (const opt of options) {
+      const g = opt.group || "";
+      if (!groups.has(g)) groups.set(g, []);
+      groups.get(g)!.push(opt);
+    }
+  }
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)} id={id}>
+      <button
+        type="button"
+        onClick={() => !disabled && setOpen(!open)}
+        disabled={disabled}
+        className={cn(
+          "flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm",
+          "focus:outline-none focus:ring-1 focus:ring-ring",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          !selected && "text-muted-foreground",
+        )}
+      >
+        <span className="truncate">{selected?.label || placeholder}</span>
+        <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 top-full mt-1 w-full rounded-md border bg-popover shadow-lg animate-in fade-in-0 zoom-in-95">
+          <Command>
+            <CommandInput placeholder={searchPlaceholder} />
+            <CommandList>
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+              {hasGroups ? (
+                Array.from(groups.entries()).map(([group, opts]) => (
+                  <CommandGroup key={group} heading={group || undefined}>
+                    {opts.map((opt) => (
+                      <CommandItem
+                        key={opt.value}
+                        value={`${opt.label} ${opt.value}`}
+                        onSelect={() => {
+                          onChange(opt.value);
+                          setOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "h-4 w-4 shrink-0",
+                            opt.value === value ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        {opt.label}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ))
+              ) : (
+                <CommandGroup>
+                  {options.map((opt) => (
+                    <CommandItem
+                      key={opt.value}
+                      value={`${opt.label} ${opt.value}`}
+                      onSelect={() => {
+                        onChange(opt.value);
+                        setOpen(false);
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "h-4 w-4 shrink-0",
+                          opt.value === value ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      {opt.label}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+            </CommandList>
+          </Command>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/ui/dropdown.tsx
+++ b/packages/sogrim-app-v2/src/components/ui/dropdown.tsx
@@ -1,0 +1,90 @@
+import { useState, useRef, useEffect } from "react";
+import { ChevronDown, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface DropdownOption {
+  value: string;
+  label: string;
+}
+
+interface DropdownProps {
+  options: DropdownOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Dropdown({
+  options,
+  value,
+  onChange,
+  placeholder = "--",
+  disabled = false,
+  className,
+}: DropdownProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)}>
+      <button
+        type="button"
+        onClick={() => !disabled && setOpen(!open)}
+        disabled={disabled}
+        className={cn(
+          "flex h-8 w-full items-center justify-between rounded-md border border-input bg-transparent px-2 py-1 text-sm",
+          "focus:outline-none focus:ring-1 focus:ring-ring",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          !selected && "text-muted-foreground",
+        )}
+      >
+        <span className="truncate">{selected?.label || placeholder}</span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 top-full mt-1 w-full min-w-[120px] max-h-[200px] overflow-y-auto rounded-md border bg-popover shadow-lg animate-in fade-in-0 zoom-in-95">
+          {options.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => {
+                onChange(opt.value);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 px-2 py-1.5 text-sm",
+                "hover:bg-accent hover:text-accent-foreground",
+                "transition-colors cursor-pointer",
+                opt.value === value && "bg-accent/50",
+              )}
+            >
+              <Check
+                className={cn(
+                  "h-3.5 w-3.5 shrink-0",
+                  opt.value === value ? "opacity-100" : "opacity-0",
+                )}
+              />
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/sogrim-app-v2/src/data/api-provider.ts
+++ b/packages/sogrim-app-v2/src/data/api-provider.ts
@@ -37,6 +37,7 @@ interface SapExam {
   date?: string;
   begin_time?: string;
   end_time?: string;
+  note?: string;
 }
 
 interface SapRelation {
@@ -64,6 +65,8 @@ interface SapOfferedPeriod {
 
 interface SapScheduleGroup {
   group: string;
+  /** Group-level name (e.g. "נבחרת טניס נשים" for sport courses). */
+  name?: string;
   events: SapScheduleEvent[];
 }
 
@@ -174,7 +177,12 @@ function toSchedule(sap: SapCourseDetails): CourseSchedule {
     }
 
     for (const [type, lessons] of byKind) {
-      groups.push({ id: `${sapGroup.group}-${type}`, type, lessons });
+      groups.push({
+        id: `${sapGroup.group}-${type}`,
+        type,
+        displayName: sapGroup.name || undefined,
+        lessons,
+      });
     }
   }
 

--- a/packages/sogrim-app-v2/src/lib/timetable-utils.ts
+++ b/packages/sogrim-app-v2/src/lib/timetable-utils.ts
@@ -27,18 +27,18 @@ export const LESSON_TYPE_NAMES: Record<LessonType, string> = {
   seminar: "סמינר",
 };
 
-/** Grid hours range */
-export const DEFAULT_START_HOUR = 8;
-export const DEFAULT_END_HOUR = 18; // Show up to 17:30 by default
-export const MIN_START_HOUR = 7;    // Can shrink down to 07:00
-export const MAX_END_HOUR = 24;     // Can expand up to midnight
+/** Grid range in hours (can be half-hour values like 8.5 = 08:30).
+ *  Defaults: 08:30 - 18:30. */
+export const DEFAULT_START_HOUR = 8.5;
+export const DEFAULT_END_HOUR = 18.5;
+export const MIN_START_HOUR = 7;     // Can shrink down to 07:00
+export const MAX_END_HOUR = 24;      // Can expand up to midnight
 export const SLOT_MINUTES = 30;
 export const SLOTS_PER_HOUR = 60 / SLOT_MINUTES;
 
 /** Compute visible start and end hours based on events.
- *  When there are no events, shows the default range (08:00-18:00).
- *  When there are events, fits to span from 1 hour before the earliest
- *  event to the hour after the latest event, with a minimum 10-hour window. */
+ *  Snaps to 30-min boundaries.
+ *  Returns values like 7.5 = 07:30, 8 = 08:00, 18.5 = 18:30. */
 export function computeVisibleRange(events: { startTime: string; endTime: string }[]): {
   startHour: number;
   endHour: number;
@@ -56,17 +56,17 @@ export function computeVisibleRange(events: { startTime: string; endTime: string
     if (end > latest) latest = end;
   }
 
-  let startHour = Math.max(Math.floor(earliest / 60), MIN_START_HOUR);
-  // Round up so the grid always contains the full last event
-  let endHour = Math.min(Math.ceil(latest / 60), MAX_END_HOUR);
+  // Floor to 30-min for start, ceil to 30-min for end.
+  let startHour = Math.floor(earliest / 30) * 0.5;
+  let endHour = Math.ceil(latest / 30) * 0.5;
 
-  // Ensure a minimum window of 10 hours for visual consistency
-  const minWindow = 10;
-  if (endHour - startHour < minWindow) {
-    const mid = (startHour + endHour) / 2;
-    startHour = Math.max(Math.floor(mid - minWindow / 2), MIN_START_HOUR);
-    endHour = Math.min(startHour + minWindow, MAX_END_HOUR);
-  }
+  // Clamp to bounds
+  startHour = Math.max(startHour, MIN_START_HOUR);
+  endHour = Math.min(endHour, MAX_END_HOUR);
+
+  // Don't shrink beyond defaults
+  startHour = Math.min(startHour, DEFAULT_START_HOUR);
+  endHour = Math.max(endHour, DEFAULT_END_HOUR);
 
   return { startHour, endHour };
 }
@@ -103,19 +103,28 @@ export function timeSpanRows(startTime: string, endTime: string): number {
   return (end - start) / SLOT_MINUTES;
 }
 
-/** Generate time labels for the grid */
+/** Generate time labels for the grid — one per hour, aligned to startHour.
+ *  E.g. if startHour is 7.5: labels are 07:30, 08:30, 09:30, ... */
 export function getTimeLabels(startHour?: number, endHour?: number): string[] {
   const start = startHour ?? DEFAULT_START_HOUR;
   const end = endHour ?? DEFAULT_END_HOUR;
   const labels: string[] = [];
-  for (let h = start; h < end; h++) {
+  for (let h = start; h < end; h += 1) {
     labels.push(formatTime(h * 60));
   }
   return labels;
 }
 
-/** All days in order */
+/** Weekdays Sun-Thu (always shown) */
+export const WEEKDAYS: Day[] = [0, 1, 2, 3, 4];
+
+/** All days including Friday */
 export const DAYS: Day[] = [0, 1, 2, 3, 4, 5];
+
+/** Check whether any events fall on Friday */
+export function hasFridayEvents(events: { day: number }[]): boolean {
+  return events.some((e) => e.day === 5);
+}
 
 /** Generate a unique draft ID */
 export function generateDraftId(): string {

--- a/packages/sogrim-app-v2/src/stores/timetable-store.ts
+++ b/packages/sogrim-app-v2/src/stores/timetable-store.ts
@@ -284,10 +284,11 @@ export function resolveEvents(
       if (selectedGroupId) {
         const group = typeGroups.find((g) => g.id === selectedGroupId);
         if (!group) continue;
+        const name = group.displayName || course.name;
         for (const lesson of group.lessons) {
           events.push({
             courseId: course.id,
-            courseName: course.name,
+            courseName: name,
             type: group.type,
             groupId: group.id,
             day: lesson.day,
@@ -303,10 +304,11 @@ export function resolveEvents(
 
         if (isPreviewTarget && previewingType === type) {
           for (const altGroup of typeGroups.filter((g) => g.id !== selectedGroupId)) {
+            const altName = altGroup.displayName || course.name;
             for (const lesson of altGroup.lessons) {
               events.push({
                 courseId: course.id,
-                courseName: course.name,
+                courseName: altName,
                 type: altGroup.type,
                 groupId: altGroup.id,
                 day: lesson.day,
@@ -324,10 +326,11 @@ export function resolveEvents(
         }
       } else {
         for (const group of typeGroups) {
+          const name = group.displayName || course.name;
           for (const lesson of group.lessons) {
             events.push({
               courseId: course.id,
-              courseName: course.name,
+              courseName: name,
               type: group.type,
               groupId: group.id,
               day: lesson.day,

--- a/packages/sogrim-app-v2/src/types/timetable.ts
+++ b/packages/sogrim-app-v2/src/types/timetable.ts
@@ -15,6 +15,8 @@ export interface Lesson {
 export interface LessonGroup {
   id: string; // e.g. "11", "12"
   type: LessonType;
+  /** Display name for sport groups (e.g. "נבחרת טניס נשים"). */
+  displayName?: string;
   lessons: Lesson[];
 }
 


### PR DESCRIPTION
## Summary
- **SAP fetcher**: 8-digit course IDs, Friday schedules, multi-slot events, sport team names, expanded building map, exam hierarchy, is_english/is_malag/is_sport flags
- **Timetable**: conditional Friday column, side-by-side overlap layout, RTL-correct positioning, 30-min grid boundaries, richer course blocks with sport names
- **UI**: new Combobox (searchable) and Dropdown components replacing all native `<select>` elements

## Test plan
- [x] `cargo test` — 92 passed, 0 failed
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [x] `tsc --noEmit` — clean
- [x] Manual: timetable with sport courses shows team names + Friday column
- [x] Manual: catalog selector is searchable
- [x] Manual: grade/category dropdowns use custom components

🤖 Generated with [Claude Code](https://claude.com/claude-code)