### PR TITLE
fix(app-v2): restore palette tokens in banner & modified-toast (#273 regression)

### DIFF
--- a/packages/sogrim-app-v2/src/components/planner/banner.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/banner.tsx
@@ -89,16 +89,16 @@ function GPASparkline({ data }: { data: { semester: string; gpa: number }[] }) {
             <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
           </linearGradient>
         </defs>
-        <path d={area} fill="url(#sparkfill)" className="text-[#d66563]" />
+        <path d={area} fill="url(#sparkfill)" className="text-progress-active" />
         <path d={path} fill="none" stroke="currentColor" strokeWidth="1.5"
-          strokeLinejoin="round" strokeLinecap="round" className="text-[#d66563]" />
+          strokeLinejoin="round" strokeLinecap="round" className="text-progress-active" />
         {data.map((d, i) => (
           <circle
             key={i}
             cx={x(i)}
             cy={y(d.gpa)}
             r="2"
-            className={cn("fill-[#d66563]", activeIdx === i && "opacity-0")}
+            className={cn("fill-progress-active", activeIdx === i && "opacity-0")}
           />
         ))}
         {activeIdx != null && active && (
@@ -111,20 +111,20 @@ function GPASparkline({ data }: { data: { semester: string; gpa: number }[] }) {
               stroke="currentColor"
               strokeWidth="1"
               strokeDasharray="2 2"
-              className="text-[#d66563]/40"
+              className="text-progress-active/40"
               vectorEffect="non-scaling-stroke"
             />
             <circle
               cx={x(activeIdx)}
               cy={y(active.gpa)}
               r="5"
-              className="fill-[#d66563]/25"
+              className="fill-progress-active/25"
             />
             <circle
               cx={x(activeIdx)}
               cy={y(active.gpa)}
               r="2.75"
-              className="fill-[#d66563]"
+              className="fill-progress-active"
               stroke="white"
               strokeWidth="1"
               vectorEffect="non-scaling-stroke"
@@ -236,7 +236,7 @@ export function Banner({ degreeStatus, catalog, includeInProgress, onToggleInPro
   return (
     <div
       className="md:-mx-6 md:px-6 md:py-5"
-      style={{ backgroundColor: "#24333c" }}
+      style={{ background: "var(--banner-bg, var(--banner))" }}
     >
       {/* ===== MOBILE: Compact summary strip ===== */}
       <div className="md:hidden px-4 py-3">
@@ -251,7 +251,7 @@ export function Banner({ degreeStatus, catalog, includeInProgress, onToggleInPro
             <div className="flex-1 h-2 rounded-full bg-white/20 overflow-hidden">
               <div
                 className="h-full rounded-full transition-all"
-                style={{ width: `${pct}%`, backgroundColor: pct >= 100 ? "#4ade80" : "#d66563" }}
+                style={{ width: `${pct}%`, backgroundColor: pct >= 100 ? "var(--ui-progress-complete)" : "var(--ui-progress-active)" }}
               />
             </div>
             <span className="text-xs text-white/70 shrink-0">
@@ -334,7 +334,7 @@ export function Banner({ degreeStatus, catalog, includeInProgress, onToggleInPro
             <div className="flex-1 h-2.5 rounded-full bg-muted overflow-hidden">
               <div
                 className="h-full rounded-full transition-all duration-700"
-                style={{ width: `${pct}%`, backgroundColor: pct >= 100 ? "#4ade80" : "#d66563" }}
+                style={{ width: `${pct}%`, backgroundColor: pct >= 100 ? "var(--ui-progress-complete)" : "var(--ui-progress-active)" }}
               />
             </div>
           </div>

--- a/packages/sogrim-app-v2/src/components/planner/modified-toast.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/modified-toast.tsx
@@ -9,7 +9,7 @@ export function ModifiedToast({ visible = true }: { visible?: boolean }) {
 
   return (
     <div
-      className="flex flex-wrap items-center justify-center gap-2 px-3 py-2.5 text-sm rounded-lg mb-2 md:rounded-none md:-mx-6 md:px-6 md:mb-0 md:-mt-6 md:-mb-3 relative z-10 bg-[#e8dff5] text-[#3b2069] dark:bg-[#2d1f4e] dark:text-[#d4c4f0]"
+      className="flex flex-wrap items-center justify-center gap-2 px-3 py-2.5 text-sm rounded-lg mb-2 md:rounded-none md:-mx-6 md:px-6 md:mb-0 md:-mt-6 md:-mb-3 relative z-10 bg-notice-bg text-notice-fg"
       style={{ visibility: visible ? "visible" : "hidden" }}
     >
       <span className="text-center font-medium text-xs md:text-sm">
@@ -20,7 +20,7 @@ export function ModifiedToast({ visible = true }: { visible?: boolean }) {
         size="sm"
         onClick={() => mutate()}
         disabled={isPending}
-        className="bg-[#7c5cbf] hover:bg-[#6a4da6] text-white text-xs h-7"
+        className="bg-notice-accent hover:bg-notice-accent-hover text-notice-accent-fg text-xs h-7"
       >
         {isPending ? (
           <>
@@ -35,7 +35,7 @@ export function ModifiedToast({ visible = true }: { visible?: boolean }) {
       <div className="relative">
         <button
           onClick={() => setShowInfo(!showInfo)}
-          className="flex items-center gap-1 text-[10px] md:text-xs text-[#7c5cbf] hover:text-[#6a4da6] dark:text-[#b69df0] dark:hover:text-[#c9b4f5] underline"
+          className="flex items-center gap-1 text-[10px] md:text-xs text-notice-link hover:text-notice-link-hover underline"
           type="button"
         >
           <Info className="h-3 w-3" />
@@ -46,7 +46,7 @@ export function ModifiedToast({ visible = true }: { visible?: boolean }) {
             {"כאשר מבוצע שינוי בקורסים (הוספה, עריכה או מחיקה), יש להריץ מחדש את חישוב סגירת התואר כדי לעדכן את הסטטוס."}
             <button
               onClick={() => setShowInfo(false)}
-              className="mt-1 block text-[#7c5cbf] hover:underline"
+              className="mt-1 block text-notice-link hover:underline"
             >
               {"סגור"}
             </button>


### PR DESCRIPTION
## Problem
The multi-palette system (#271) regressed: the degree-stats **banner** and the "status not updated" **notice** are frozen to one palette's colors regardless of the selected palette (card background stays teal `#24333c`, chart/progress stay salmon `#d66563`). Looked like a theme/CORS bug in the wild.

## Root cause
**#273 ("Session and UI fixes") accidentally reverted** the palette CSS-variable references in `banner.tsx` and `modified-toast.tsx` back to hardcoded literals — almost certainly a bad merge/rebase, since that commit's stated purpose was unrelated to these files. It only became visible now because the `#271`+`#273` code finally went live.

| Element | `#271` (correct) | `#273` regression |
|---|---|---|
| Banner card bg | `var(--banner-bg, var(--banner))` | `#24333c` |
| Sparkline chart | `text/fill-progress-active` | `text/fill-[#d66563]` |
| Banner progress bars | `var(--ui-progress-complete/active)` | `#4ade80` / `#d66563` |
| Toast container/button/links | `notice-bg/fg`, `notice-accent(+hover/fg)`, `notice-link(+hover)` | hardcoded purples |

## Fix
Restore the palette tokens — the correct values already exist at `9ce32a5`. Pure token restoration (13-for-13 line replacement), no design changes.

## Audit (exhaustive)
Swept the whole `sogrim-app-v2` tree (net token-removal diff + full-tree hex scan). **Only these 2 files regressed.** `course-grid` AG-Grid header (`#24333c`) and `settings-page` palette swatches are intentional and unchanged since `#271` — left as-is.

## Verification
- `tsc -b` + `vite build` pass.
- Built CSS confirms each restored utility binds to a palette var, and `--ui-progress-active` resolves to **different values per palette** (`#d66563` Classic / `#8b2e3d` Botanical / `#db2777` …) — the banner now follows the selected palette instead of being frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
