### PR TITLE
feat(app-v2): replace native title tooltips with <Hint> + lint guard

### DIFF
--- a/packages/sogrim-app-v2/eslint.config.js
+++ b/packages/sogrim-app-v2/eslint.config.js
@@ -19,5 +19,32 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Native `title` tooltips are laggy (multi-second delay) and unstyled.
+      // Use the <Hint> component (src/components/ui/hint.tsx) instead. This only
+      // bans `title` on host (lowercase) DOM elements; component props named
+      // `title` (e.g. <DetailSection title=...>) are unaffected.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "JSXOpeningElement[name.name=/^[a-z]/] > JSXAttribute[name.name='title']",
+          message:
+            'Use the <Hint label="..."> component instead of a native `title` attribute (native tooltips are laggy and unstyled).',
+        },
+      ],
+    },
+  },
+  {
+    // EXCEPTION: the semester timeline's slots are dnd-kit draggables that spread
+    // `{...listeners}`/`{...attributes}` onto the same node as `title`. Wrapping
+    // them in <Hint> (Radix `asChild`) would merge pointer handlers onto the drag
+    // node and risk breaking drag-and-drop. These native titles are retained
+    // intentionally until a drag-safe (controlled) tooltip is implemented.
+    // TODO(benny-n): convert timeline slot tooltips with a controlled <Hint>.
+    files: ['src/components/planner/semester-timeline.tsx'],
+    rules: {
+      'no-restricted-syntax': 'off',
+    },
   },
 ])

--- a/packages/sogrim-app-v2/src/components/layout/sidebar.tsx
+++ b/packages/sogrim-app-v2/src/components/layout/sidebar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "@tanstack/react-router";
 import { GraduationCap, Calendar, Settings, Mail, ChevronRight, ChevronLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUiStore } from "@/stores/ui-store";
+import { Hint } from "@/components/ui/hint";
 
 const navItems = [
   { to: "/planner" as const, label: "מעקב תואר", icon: GraduationCap },
@@ -34,21 +35,21 @@ export function Sidebar() {
         {navItems.map((item) => {
           const isActive = location.pathname === item.to;
           return (
-            <Link
-              key={item.to}
-              to={item.to}
-              title={collapsed ? item.label : undefined}
-              className={cn(
-                "flex items-center rounded-lg text-sm font-medium transition-colors",
-                collapsed ? "justify-center px-2 py-2.5" : "gap-3 px-3 py-2.5",
-                isActive
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              )}
-            >
-              <item.icon className="h-5 w-5 shrink-0" />
-              {!collapsed && <span>{item.label}</span>}
-            </Link>
+            <Hint key={item.to} label={collapsed ? item.label : undefined} side="left">
+              <Link
+                to={item.to}
+                className={cn(
+                  "flex items-center rounded-lg text-sm font-medium transition-colors",
+                  collapsed ? "justify-center px-2 py-2.5" : "gap-3 px-3 py-2.5",
+                  isActive
+                    ? "bg-primary text-primary-foreground shadow-sm"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                )}
+              >
+                <item.icon className="h-5 w-5 shrink-0" />
+                {!collapsed && <span>{item.label}</span>}
+              </Link>
+            </Hint>
           );
         })}
       </nav>

--- a/packages/sogrim-app-v2/src/components/planner/add-course-form.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/add-course-form.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react
 import { Plus, X, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dropdown } from "@/components/ui/dropdown";
+import { Hint } from "@/components/ui/hint";
 import { cn, computeDropUp } from "@/lib/utils";
 import { courseFromUserValidations } from "@/lib/course-validator";
 import { COURSE_GRADE_OPTIONS } from "@/types/domain";
@@ -356,24 +357,26 @@ export function AddCourseForm({
 
         {/* Action buttons */}
         <div className="flex items-center gap-1">
-          <button
-            onClick={handleSubmit}
-            className="flex items-center justify-center h-8 w-8 rounded-full bg-foreground text-background hover:bg-foreground/80 transition-colors"
-            title="הוסף"
-          >
-            <Plus className="h-4 w-4" />
-          </button>
-          <button
-            onClick={() => {
-              resetForm();
-              setToast(null);
-              setExpanded(false);
-            }}
-            className="flex items-center justify-center h-8 w-8 rounded-full border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
-            title="ביטול"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <Hint label="הוסף">
+            <button
+              onClick={handleSubmit}
+              className="flex items-center justify-center h-8 w-8 rounded-full bg-foreground text-background hover:bg-foreground/80 transition-colors"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </Hint>
+          <Hint label="ביטול">
+            <button
+              onClick={() => {
+                resetForm();
+                setToast(null);
+                setExpanded(false);
+              }}
+              className="flex items-center justify-center h-8 w-8 rounded-full border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </Hint>
         </div>
       </div>
 

--- a/packages/sogrim-app-v2/src/components/planner/banner.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/banner.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef } from "react";
 import { ChevronDown, ChevronUp, BookOpenCheck, Target, CalendarRange, CalendarDays, ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Hint } from "@/components/ui/hint";
 import { isSocialActivityCourse } from "@/lib/reserved-credits";
 import { formatSemesterName, parseSemesterOrder, semesterKey, semestersEqual } from "@/lib/semester-utils";
 import type { AcademicSemester, DegreeStatus, Catalog, CourseStatus } from "@/types/api";
@@ -352,13 +353,12 @@ export function Banner({ degreeStatus, catalog, includeInProgress, onToggleInPro
             <span className="text-3xl font-bold text-foreground tabular-nums">{gpa}</span>
             <span className="text-xs text-muted-foreground">ממוצע כללי</span>
             {gpaDelta != null && gpaDelta > 0 && (
-              <span
-                className="inline-flex items-center gap-0.5 text-[10px] font-medium tabular-nums text-green-600 dark:text-green-400"
-                title="עלייה לעומת הסמסטר הקודם"
-              >
-                <ArrowUpRight className="h-3 w-3" />
-                +{gpaDelta.toFixed(1)}
-              </span>
+              <Hint label="עלייה לעומת הסמסטר הקודם">
+                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium tabular-nums text-green-600 dark:text-green-400">
+                  <ArrowUpRight className="h-3 w-3" />
+                  +{gpaDelta.toFixed(1)}
+                </span>
+              </Hint>
             )}
           </div>
 

--- a/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
@@ -10,6 +10,7 @@ import { Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Toast } from "@/components/ui/toast";
 import { GradeEditor } from "@/components/planner/grid-cells/grade-editor";
+import { Hint } from "@/components/ui/hint";
 import {
   courseFromUserValidations,
   determineState,
@@ -231,13 +232,14 @@ export function CourseGrid({
           const courseNumber = params.data.courseNumber;
           const courseSemester = params.data.semester;
           return (
-            <button
-              onClick={() => onDelete(courseNumber, courseSemester)}
-              className="flex items-center justify-center h-full w-full text-muted-foreground hover:text-destructive transition-colors"
-              title="מחק קורס"
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
+            <Hint label="מחק קורס">
+              <button
+                onClick={() => onDelete(courseNumber, courseSemester)}
+                className="flex items-center justify-center h-full w-full text-muted-foreground hover:text-destructive transition-colors"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </Hint>
           );
         },
       },

--- a/packages/sogrim-app-v2/src/components/planner/exemptions-tab.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/exemptions-tab.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dropdown } from "@/components/ui/dropdown";
+import { Hint } from "@/components/ui/hint";
 import type { CourseStatus } from "@/types/api";
 import type { RowData } from "@/types/domain";
 import { courseSemesterKey } from "@/lib/semester-utils";
@@ -107,13 +108,14 @@ export function ExemptionsTab({
               </Badge>
             </div>
             <div className="col-span-1 flex justify-center items-center">
-              <button
-                onClick={() => onDeleteCourse(cs.course._id, null)}
-                className="flex items-center justify-center text-muted-foreground hover:text-destructive transition-colors"
-                title="מחק קורס"
-              >
-                <Trash2 className="h-4 w-4" />
-              </button>
+              <Hint label="מחק קורס">
+                <button
+                  onClick={() => onDeleteCourse(cs.course._id, null)}
+                  className="flex items-center justify-center text-muted-foreground hover:text-destructive transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </Hint>
             </div>
           </div>
         ))}
@@ -199,24 +201,26 @@ export function ExemptionsTab({
 
                 {/* Action buttons */}
                 <div className="flex items-center gap-1">
-                  <button
-                    onClick={handleAdd}
-                    disabled={!selectedCourseId}
-                    className="flex items-center justify-center h-8 w-8 rounded-full bg-foreground text-background hover:bg-foreground/80 transition-colors disabled:opacity-40"
-                    title="הוסף"
-                  >
-                    <Plus className="h-4 w-4" />
-                  </button>
-                  <button
-                    onClick={() => {
-                      setSelectedCourseId("");
-                      setExpanded(false);
-                    }}
-                    className="flex items-center justify-center h-8 w-8 rounded-full border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
-                    title="ביטול"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
+                  <Hint label="הוסף">
+                    <button
+                      onClick={handleAdd}
+                      disabled={!selectedCourseId}
+                      className="flex items-center justify-center h-8 w-8 rounded-full bg-foreground text-background hover:bg-foreground/80 transition-colors disabled:opacity-40"
+                    >
+                      <Plus className="h-4 w-4" />
+                    </button>
+                  </Hint>
+                  <Hint label="ביטול">
+                    <button
+                      onClick={() => {
+                        setSelectedCourseId("");
+                        setExpanded(false);
+                      }}
+                      className="flex items-center justify-center h-8 w-8 rounded-full border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </Hint>
                 </div>
               </div>
             </div>

--- a/packages/sogrim-app-v2/src/components/planner/grid-cells/grade-editor.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/grid-cells/grade-editor.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import type { CustomCellEditorProps } from "ag-grid-react";
 import { COURSE_GRADE_OPTIONS } from "@/types/domain";
 import type { RowData } from "@/types/domain";
+import { Hint } from "@/components/ui/hint";
 
 const EXEMPTION_OPTIONS = COURSE_GRADE_OPTIONS.filter((opt) =>
   opt.includes("פטור")
@@ -113,17 +114,18 @@ export function GradeEditor(
   return (
     <div className="flex items-center h-full gap-1.5 px-2 bg-card w-[200px]">
       {/* Toggle icon - wand */}
-      <button
-        type="button"
-        onMouseDown={toggle}
-        className="shrink-0 text-muted-foreground hover:text-info transition-colors"
-        title={isNumeric ? "ציון לא מספרי" : "ציון מספרי"}
-      >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72" />
-          <path d="m14 7 3 3" />
-        </svg>
-      </button>
+      <Hint label={isNumeric ? "ציון לא מספרי" : "ציון מספרי"}>
+        <button
+          type="button"
+          onMouseDown={toggle}
+          className="shrink-0 text-muted-foreground hover:text-info transition-colors"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72" />
+            <path d="m14 7 3 3" />
+          </svg>
+        </button>
+      </Hint>
 
       {/* Input or select */}
       {isNumeric ? (

--- a/packages/sogrim-app-v2/src/components/planner/planner-course-search.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/planner-course-search.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Dropdown } from "@/components/ui/dropdown";
 import { Toast } from "@/components/ui/toast";
 import { useIsOgPalette } from "@/stores/ui-store";
+import { Hint } from "@/components/ui/hint";
 
 interface PlannerCourseSearchProps {
   semester: AcademicSemester | null;
@@ -213,20 +214,22 @@ export function PlannerCourseSearch({
 
         {/* Action buttons — push down past the (invisible) label row to align with inputs */}
         <div className="flex items-center gap-1 mt-[18px]">
-          <button
-            onClick={handleSubmit}
-            className="flex items-center justify-center h-8 w-8 rounded-full bg-foreground text-background hover:bg-foreground/80 transition-colors"
-            title="אישור"
-          >
-            <Check className="h-4 w-4" />
-          </button>
-          <button
-            onClick={resetForm}
-            className="flex items-center justify-center h-8 w-8 rounded-full border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
-            title="ביטול"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <Hint label="אישור">
+            <button
+              onClick={handleSubmit}
+              className="flex items-center justify-center h-8 w-8 rounded-full bg-foreground text-background hover:bg-foreground/80 transition-colors"
+            >
+              <Check className="h-4 w-4" />
+            </button>
+          </Hint>
+          <Hint label="ביטול">
+            <button
+              onClick={resetForm}
+              className="flex items-center justify-center h-8 w-8 rounded-full border border-border text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </Hint>
         </div>
       </div>
 

--- a/packages/sogrim-app-v2/src/components/planner/requirements/bank-requirement-card.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/requirements/bank-requirement-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import type { CourseBankReq, CourseStatus } from "@/types/api";
 import { isReservedCourse } from "@/lib/reserved-credits";
+import { Hint } from "@/components/ui/hint";
 
 interface BankRequirementCardProps {
   bank: CourseBankReq;
@@ -84,9 +85,11 @@ export function BankRequirementCard({
                 {bank.course_bank_name}
               </span>
               {bank.message && (
-                <span title={bank.message}>
-                  <Info className="h-3.5 w-3.5 text-muted-foreground" />
-                </span>
+                <Hint label={bank.message}>
+                  <span>
+                    <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                  </span>
+                </Hint>
               )}
             </div>
             <Badge

--- a/packages/sogrim-app-v2/src/components/planner/reserved-credits-panel.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/reserved-credits-panel.tsx
@@ -13,6 +13,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Hint } from "@/components/ui/hint";
 import { useUserState } from "@/hooks/use-user-state";
 import { useUpdateUserState } from "@/hooks/use-mutations";
 import {
@@ -72,17 +73,18 @@ function CreditInput({
   }
 
   return (
-    <button
-      onClick={startEdit}
-      className={`w-9 h-7 flex items-center justify-center text-sm font-bold rounded border cursor-text transition-colors hover:border-primary ${
-        isOverAllocated && value > 0
-          ? "text-destructive border-destructive/40"
-          : "text-foreground border-border"
-      }`}
-      title="לחץ לעריכה"
-    >
-      {value}
-    </button>
+    <Hint label="לחץ לעריכה">
+      <button
+        onClick={startEdit}
+        className={`w-9 h-7 flex items-center justify-center text-sm font-bold rounded border cursor-text transition-colors hover:border-primary ${
+          isOverAllocated && value > 0
+            ? "text-destructive border-destructive/40"
+            : "text-foreground border-border"
+        }`}
+      >
+        {value}
+      </button>
+    </Hint>
   );
 }
 
@@ -219,26 +221,28 @@ export function ReservedCreditsPanel() {
                     {bankName}
                   </span>
                   <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => handleDelta(bankName, CREDIT_STEP)}
-                      className="w-7 h-7 flex items-center justify-center rounded border text-muted-foreground hover:text-foreground hover:border-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                      title={"הוסף נקודות"}
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                    </button>
+                    <Hint label="הוסף נקודות">
+                      <button
+                        onClick={() => handleDelta(bankName, CREDIT_STEP)}
+                        className="w-7 h-7 flex items-center justify-center rounded border text-muted-foreground hover:text-foreground hover:border-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                      </button>
+                    </Hint>
                     <CreditInput
                       value={allocated}
                       onChange={(v) => handleSet(bankName, v)}
                       isOverAllocated={isOverAllocated}
                     />
-                    <button
-                      onClick={() => handleDelta(bankName, -CREDIT_STEP)}
-                      disabled={allocated <= 0}
-                      className="w-7 h-7 flex items-center justify-center rounded border text-muted-foreground hover:text-foreground hover:border-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                      title={"הפחת נקודות"}
-                    >
-                      <Minus className="h-3.5 w-3.5" />
-                    </button>
+                    <Hint label="הפחת נקודות">
+                      <button
+                        onClick={() => handleDelta(bankName, -CREDIT_STEP)}
+                        disabled={allocated <= 0}
+                        className="w-7 h-7 flex items-center justify-center rounded border text-muted-foreground hover:text-foreground hover:border-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      >
+                        <Minus className="h-3.5 w-3.5" />
+                      </button>
+                    </Hint>
                   </div>
                 </div>
               );

--- a/packages/sogrim-app-v2/src/components/timetable/course-block.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/course-block.tsx
@@ -5,6 +5,7 @@ import { useTimetableStore } from "@/stores/timetable-store";
 import { useUiStore } from "@/stores/ui-store";
 import { cn } from "@/lib/utils";
 import { Star } from "lucide-react";
+import { Hint } from "@/components/ui/hint";
 
 interface CourseBlockProps {
   event: TimetableEvent;
@@ -43,9 +44,20 @@ export function CourseBlock({ event, compact = false, onCustomEventClick }: Cour
 
   const isPreview = !!event.isPreview;
 
+  const blockTitle = [
+    event.courseName,
+    !event.isCustom && event.kindLabel,
+    location,
+    event.instructor,
+    isPreview && "לחצו לבחור",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
   return (
-    <div
-      onClick={handleClick}
+    <Hint label={blockTitle}>
+      <div
+        onClick={handleClick}
       className={cn(
         "rounded-sm cursor-pointer h-full overflow-hidden",
         "flex flex-col items-start justify-start text-start",
@@ -68,14 +80,7 @@ export function CourseBlock({ event, compact = false, onCustomEventClick }: Cour
         color: isPreview ? "var(--course-bg)" : "var(--course-text)",
         borderColor: "var(--course-border)",
       }}
-      title={[
-        event.courseName,
-        !event.isCustom && event.kindLabel,
-        location,
-        event.instructor,
-        isPreview && "לחצו לבחור",
-      ].filter(Boolean).join(" · ")}
-    >
+      >
       {event.isCustom && !compact && (
         <Star className="absolute top-0.5 left-0.5 h-2 w-2 opacity-60" />
       )}
@@ -92,6 +97,7 @@ export function CourseBlock({ event, compact = false, onCustomEventClick }: Cour
           {event.courseName}
         </div>
       )}
-    </div>
+      </div>
+    </Hint>
   );
 }

--- a/packages/sogrim-app-v2/src/components/timetable/custom-event-dialog.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/custom-event-dialog.tsx
@@ -4,6 +4,7 @@ import { useTimetableStore } from "@/stores/timetable-store";
 import { DAY_NAMES, formatTime, DEFAULT_START_HOUR, MAX_END_HOUR, SLOT_MINUTES } from "@/lib/timetable-utils";
 import { cn } from "@/lib/utils";
 import { X, Clock, Pencil } from "lucide-react";
+import { Hint } from "@/components/ui/hint";
 
 const EVENT_COLORS = [
   { id: "gray", bg: "oklch(0.65 0.02 250)", label: "אפור" },
@@ -163,16 +164,16 @@ export function CustomEventDialog({
             <span className="text-xs text-muted-foreground">צבע:</span>
             <div className="flex gap-1">
               {EVENT_COLORS.map((c) => (
-                <button
-                  key={c.id}
-                  onClick={() => setSelectedColor(c.id)}
-                  title={c.label}
-                  className={cn(
-                    "w-6 h-6 rounded-full transition-all",
-                    selectedColor === c.id && "ring-2 ring-offset-2 ring-primary",
-                  )}
-                  style={{ backgroundColor: c.bg }}
-                />
+                <Hint key={c.id} label={c.label}>
+                  <button
+                    onClick={() => setSelectedColor(c.id)}
+                    className={cn(
+                      "w-6 h-6 rounded-full transition-all",
+                      selectedColor === c.id && "ring-2 ring-offset-2 ring-primary",
+                    )}
+                    style={{ backgroundColor: c.bg }}
+                  />
+                </Hint>
               ))}
             </div>
           </div>

--- a/packages/sogrim-app-v2/src/components/timetable/group-selector.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/group-selector.tsx
@@ -3,6 +3,7 @@ import { LESSON_TYPE_NAMES, DAY_LABELS } from "@/lib/timetable-utils";
 import { useTimetableStore } from "@/stores/timetable-store";
 import { cn } from "@/lib/utils";
 import { Eye } from "lucide-react";
+import { Hint } from "@/components/ui/hint";
 
 interface GroupSelectorProps {
   course: CourseSchedule;
@@ -49,42 +50,43 @@ export function GroupSelector({ course, selectedGroups }: GroupSelectorProps) {
             </span>
             <div className="flex gap-0.5 flex-wrap">
               {groups.map((g) => (
-                <button
-                  key={g.id}
-                  onClick={() => setGroup(course.id, type, g.id)}
-                  title={g.summary}
-                  className={cn(
-                    "px-1.5 py-0.5 rounded text-[0.65rem] font-medium transition-all",
-                    g.id === selectedId
-                      ? "bg-primary text-primary-foreground"
-                      : isTypePreview
-                        ? "bg-primary/20 text-primary ring-1 ring-primary/30"
-                        : "bg-secondary text-secondary-foreground hover:bg-accent",
-                  )}
-                >
-                  {g.id.split("-")[0]}
-                </button>
+                <Hint key={g.id} label={g.summary}>
+                  <button
+                    onClick={() => setGroup(course.id, type, g.id)}
+                    className={cn(
+                      "px-1.5 py-0.5 rounded text-[0.65rem] font-medium transition-all",
+                      g.id === selectedId
+                        ? "bg-primary text-primary-foreground"
+                        : isTypePreview
+                          ? "bg-primary/20 text-primary ring-1 ring-primary/30"
+                          : "bg-secondary text-secondary-foreground hover:bg-accent",
+                    )}
+                  >
+                    {g.id.split("-")[0]}
+                  </button>
+                </Hint>
               ))}
             </div>
             {/* Preview all button */}
-            <button
-              onClick={() => {
-                if (isTypePreview) {
-                  setPreview(null, null);
-                } else {
-                  setPreview(course.id, type);
-                }
-              }}
-              title="הצג את כל האפשרויות על המערכת"
-              className={cn(
-                "p-0.5 rounded transition-colors",
-                isTypePreview
-                  ? "text-primary bg-primary/10"
-                  : "text-muted-foreground hover:text-primary",
-              )}
-            >
-              <Eye className="h-3 w-3" />
-            </button>
+            <Hint label="הצג את כל האפשרויות על המערכת">
+              <button
+                onClick={() => {
+                  if (isTypePreview) {
+                    setPreview(null, null);
+                  } else {
+                    setPreview(course.id, type);
+                  }
+                }}
+                className={cn(
+                  "p-0.5 rounded transition-colors",
+                  isTypePreview
+                    ? "text-primary bg-primary/10"
+                    : "text-muted-foreground hover:text-primary",
+                )}
+              >
+                <Eye className="h-3 w-3" />
+              </button>
+            </Hint>
           </div>
         );
       })}

--- a/packages/sogrim-app-v2/src/components/timetable/sync-to-semesters-button.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/sync-to-semesters-button.tsx
@@ -12,6 +12,7 @@ import { useUiStore } from "@/stores/ui-store";
 import { getProvider } from "@/data/course-schedule-provider";
 import { Toast } from "@/components/ui/toast";
 import { Button } from "@/components/ui/button";
+import { Hint } from "@/components/ui/hint";
 import {
   formatSemesterName,
   getAllSemesters,
@@ -276,25 +277,29 @@ export function SyncToSemestersButton() {
 
   return (
     <>
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={isDisabled}
-        title={tooltip}
-        aria-label={tooltip}
-        className={cn(
-          "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors",
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-          "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-background disabled:hover:text-foreground",
-        )}
-      >
-        {updateMutation.isPending ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <RefreshCw className="h-4 w-4" />
-        )}
-        <span className="hidden sm:inline">סנכרן לסמסטרים</span>
-      </button>
+      <Hint label={tooltip}>
+        {/* span trigger so the tooltip still shows when the button is disabled */}
+        <span className="inline-flex">
+          <button
+            type="button"
+            onClick={handleClick}
+            disabled={isDisabled}
+            aria-label={tooltip}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors",
+              "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+              "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-background disabled:hover:text-foreground",
+            )}
+          >
+            {updateMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+            <span className="hidden sm:inline">סנכרן לסמסטרים</span>
+          </button>
+        </span>
+      </Hint>
 
       {/* Confirmation dialog — only when removals are involved.
           Inline modal matches the ResetUserDialog pattern. */}

--- a/packages/sogrim-app-v2/src/components/timetable/timetable-toolbar.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/timetable-toolbar.tsx
@@ -7,6 +7,7 @@ import { SyncToSemestersButton } from "./sync-to-semesters-button";
 import type { TimetableEvent } from "@/types/timetable";
 import { Search, Cloud, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Hint } from "@/components/ui/hint";
 
 interface TimetableToolbarProps {
   events: TimetableEvent[];
@@ -29,16 +30,15 @@ export function TimetableToolbar({ events }: TimetableToolbarProps) {
         <div className="flex items-center gap-2">
           {/* Sync indicator */}
           {(syncing || lastSaved > 0) && (
-            <div
-              className="flex items-center gap-1 text-xs text-muted-foreground"
-              title={lastSaved ? `נשמר לאחרונה ${new Date(lastSaved).toLocaleTimeString("he-IL")}` : "שומר..."}
-            >
-              {syncing ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-              ) : (
-                <Cloud className="h-3.5 w-3.5 text-emerald-500" />
-              )}
-            </div>
+            <Hint label={lastSaved ? `נשמר לאחרונה ${new Date(lastSaved).toLocaleTimeString("he-IL")}` : "שומר..."}>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                {syncing ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                ) : (
+                  <Cloud className="h-3.5 w-3.5 text-emerald-500" />
+                )}
+              </div>
+            </Hint>
           )}
 
           <ViewToggle />

--- a/packages/sogrim-app-v2/src/components/ui/hint.tsx
+++ b/packages/sogrim-app-v2/src/components/ui/hint.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type TooltipContentProps = React.ComponentProps<typeof TooltipContent>;
+
+export interface HintProps {
+  /** Tooltip text. If empty/nullish, children render with no tooltip. */
+  label: React.ReactNode;
+  children: React.ReactNode;
+  side?: TooltipContentProps["side"];
+  align?: TooltipContentProps["align"];
+  className?: string;
+}
+
+/**
+ * Hover hint built on the app Tooltip primitive. Use this instead of the
+ * native `title` attribute, which is unstyled and only appears after a
+ * multi-second browser delay. Relies on the app-root <TooltipProvider/>.
+ *
+ * The single child becomes the trigger (via `asChild`), so it must be one
+ * element that forwards a ref and props (a DOM element or a component that
+ * spreads props onto one).
+ */
+export function Hint({ label, children, side = "top", align, className }: HintProps) {
+  if (label === null || label === undefined || label === "") {
+    return <>{children}</>;
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side} align={align} className={cn("max-w-xs text-right", className)}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/sogrim-app-v2/src/main.tsx
+++ b/packages/sogrim-app-v2/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 import { ErrorBoundary } from "@/components/common/error-boundary";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { startAuthRefreshLoop } from "@/lib/google-auth";
 import { router } from "./router";
 import "./index.css";
@@ -34,7 +35,9 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <TooltipProvider delayDuration={200} skipDelayDuration={300}>
+          <RouterProvider router={router} />
+        </TooltipProvider>
       </QueryClientProvider>
     </ErrorBoundary>
   </StrictMode>,


### PR DESCRIPTION
## What
Replace laggy native `title` tooltips (multi-second hover delay, unstyled) with a styled `<Hint>` tooltip built on the existing Radix Tooltip primitive — and add a lint guard so native ones can't creep back.

## Changes
- **New `src/components/ui/hint.tsx`** — `<Hint label side>` wrapper (renders nothing extra; `asChild` trigger).
- **Single app-root `<TooltipProvider delayDuration={200}>`** in `main.tsx` (snappy, vs the browser's ~1–2s).
- **Converted ~15 native `title` tooltips across 14 components**: banner GPA-delta chip, course-grid delete, add-course / course-search / exemptions buttons, reserved-credits value + steppers, requirement-bank info icon, grade wand toggle, collapsed-sidebar nav, timetable sync indicator, **sync-to-semesters button** (the originally reported one), course blocks, group selector, color picker.
- **ESLint rule** (`no-restricted-syntax`) banning `title` on host (lowercase) DOM elements so native tooltips can't return. Component props named `title` (`<DetailSection>`, `<AccordionSection>`) are unaffected. The guard already **caught one site the manual sweep missed** (`custom-event-dialog`).

## Deferred (documented)
The 4 `semester-timeline` slot tooltips sit on **dnd-kit draggables** (`{...listeners}`/`{...attributes}` spread onto the same node as `title`). Wrapping them in `<Hint asChild>` would merge pointer handlers onto the drag node and **risk breaking drag-and-drop**, so they remain native behind a documented per-file lint exception, pending a drag-safe (controlled) tooltip. **Please smoke-test that timeline drag still works** — those slots are otherwise untouched.

## Verification
- `eslint .` clean (0 native-`title` violations), `tsc -b` + `vite build` pass.

## Note on overlap with the palette-fix PR
This branch is off `master`, so the banner here still shows the **pre-fix** colors — the palette regression fix is in its sibling PR (`benny-n/fix-palette-regression`). `banner.tsx` is touched in both PRs but on **different lines** (colors vs. the GPA-delta chip wrap), so they should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
