### PR TITLE
fix(app-v2): single source of truth for faculty labels

### DIFF
--- a/packages/sogrim-app-v2/src/components/onboarding/catalog-step.tsx
+++ b/packages/sogrim-app-v2/src/components/onboarding/catalog-step.tsx
@@ -10,15 +10,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Faculty } from "@/types/api";
+import { Faculty, FACULTY_LABELS } from "@/types/api";
 import type { Catalog } from "@/types/api";
-
-const FACULTY_LABELS: Record<string, string> = {
-  ComputerScience: "מדעי המחשב",
-  DataAndDecisionScience: "מדעי הנתונים וקבלת החלטות",
-  Medicine: "רפואה",
-  Unknown: "כללי",
-};
 
 interface CatalogStepProps {
   faculty: Faculty;

--- a/packages/sogrim-app-v2/src/components/onboarding/faculty-step.tsx
+++ b/packages/sogrim-app-v2/src/components/onboarding/faculty-step.tsx
@@ -1,33 +1,16 @@
 import { GraduationCap, Monitor, BarChart3, Stethoscope } from "lucide-react";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
-import { Faculty } from "@/types/api";
+import { Faculty, FACULTY_LABELS } from "@/types/api";
 import { cn } from "@/lib/utils";
 
 const FACULTIES: {
   key: Faculty;
-  label: string;
   icon: typeof Monitor;
 }[] = [
-  {
-    key: Faculty.ComputerScience,
-    label: "מדעי המחשב",
-    icon: Monitor,
-  },
-  {
-    key: Faculty.DataAndDecisionScience,
-    label: "הנדסת תעשייה וניהול",
-    icon: BarChart3,
-  },
-  {
-    key: Faculty.Medicine,
-    label: "רפואה",
-    icon: Stethoscope,
-  },
-  {
-    key: Faculty.ElectricalEngineering,
-    label: "הנדסת חשמל",
-    icon: Monitor,
-  }
+  { key: Faculty.ComputerScience, icon: Monitor },
+  { key: Faculty.DataAndDecisionScience, icon: BarChart3 },
+  { key: Faculty.Medicine, icon: Stethoscope },
+  { key: Faculty.ElectricalEngineering, icon: Monitor },
 ];
 
 interface FacultyStepProps {
@@ -72,7 +55,7 @@ export function FacultyStep({ onSelect }: FacultyStepProps) {
                     </div>
                     <div className="space-y-1">
                       <CardTitle className="text-lg">
-                        {faculty.label}
+                        {FACULTY_LABELS[faculty.key]}
                       </CardTitle>
                     </div>
                   </div>

--- a/packages/sogrim-app-v2/src/components/settings/settings-page.tsx
+++ b/packages/sogrim-app-v2/src/components/settings/settings-page.tsx
@@ -85,15 +85,8 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Toast } from "@/components/ui/toast";
 import { ResetUserDialog } from "./reset-user-dialog";
-import type { Catalog } from "@/types/api";
-
-const FACULTY_LABELS: Record<string, string> = {
-  ComputerScience: "מדעי המחשב",
-  DataAndDecisionScience: "מדעי הנתונים וקבלת החלטות",
-  Medicine: "רפואה",
-  ElectricalEngineering: "הנדסת חשמל",
-  Unknown: "כללי",
-};
+import { FACULTY_LABELS } from "@/types/api";
+import type { Catalog, Faculty } from "@/types/api";
 
 function groupByFaculty(
   catalogs: Catalog[]
@@ -338,10 +331,10 @@ export function SettingsPage() {
                       facultyCatalogs.map((catalog) => ({
                         value: catalog._id.$oid,
                         label: `${catalog.name} (${catalog.total_credit} נ״ז)`,
-                        group: FACULTY_LABELS[faculty] || faculty,
+                        group: FACULTY_LABELS[faculty as Faculty] || faculty,
                         keywords: [
                           String(catalog.year),
-                          FACULTY_LABELS[faculty] || faculty,
+                          FACULTY_LABELS[faculty as Faculty] || faculty,
                         ],
                       }))
                   )}

--- a/packages/sogrim-app-v2/src/types/api.ts
+++ b/packages/sogrim-app-v2/src/types/api.ts
@@ -7,6 +7,16 @@ export const Faculty = {
 } as const;
 export type Faculty = (typeof Faculty)[keyof typeof Faculty];
 
+/** Single source of truth for faculty display names. `Record<Faculty, string>`
+ *  makes the build fail if a faculty is ever added without a label here. */
+export const FACULTY_LABELS: Record<Faculty, string> = {
+  Unknown: "כללי",
+  ComputerScience: "מדעי המחשב",
+  DataAndDecisionScience: "מדעי הנתונים וקבלת החלטות",
+  Medicine: "רפואה",
+  ElectricalEngineering: "הנדסת חשמל",
+};
+
 export const UserPermissions = {
   Student: "Student",
   Admin: "Admin",


### PR DESCRIPTION
## Bug
On the onboarding catalog step, Electrical Engineering students saw the raw enum `ElectricalEngineering` instead of `הנדסת חשמל` (not translated to Hebrew).

## Root cause
The faculty label was duplicated across **three** files that had drifted apart:
- `catalog-step.tsx` — **missing the `ElectricalEngineering` entry**, so it fell through `?? faculty` to the raw enum (the bug).
- `settings-page.tsx` — separate complete copy.
- `faculty-step.tsx` — separate copy that also **mislabeled `DataAndDecisionScience`**.

## Fix
One typed source of truth beside the `Faculty` enum, consumed everywhere:

```ts
export const FACULTY_LABELS: Record<Faculty, string> = { … }
```

- All three components import it; their local copies are deleted.
- EE now translates; `DataAndDecisionScience` is consistent everywhere.
- `Record<Faculty, string>` **fails the build if a faculty is added without a label**, so this drift can't recur. (It already caught a string-index slip during the change.)

Build (`tsc -b` + `vite`) and eslint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
