### PR TITLE
feat(app-v2): admin-only BI dashboard

### DIFF
--- a/packages/server/src/api/admins.rs
+++ b/packages/server/src/api/admins.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::core::degree_status::DegreeStatus;
 use crate::core::parser;
+use crate::core::stats::{DashboardStats, StatsCache, STATS_TTL};
 use crate::db::Db;
 use crate::disk_cache::DiskCourseCache;
 use crate::error::AppError;
@@ -34,4 +35,20 @@ pub async fn parse_courses_and_compute_degree_status(
     degree_status.compute(catalog, courses);
 
     Ok(Json(degree_status))
+}
+
+/// Admin-only BI dashboard statistics. Computed from a single `$facet` over the
+/// `Users` collection and memoized for a short TTL so rapid dashboard reloads
+/// don't re-scan the collection. The `_admin: User` extractor enforces the
+/// `Permissions::Admin` gate (401 below Admin) via the route group's
+/// `Extension(Permissions::Admin)`.
+pub async fn get_stats(
+    _admin: User,
+    Extension(db): Extension<Db>,
+    Extension(course_cache): Extension<Arc<DiskCourseCache>>,
+    Extension(cache): Extension<StatsCache>,
+) -> Result<Json<DashboardStats>, AppError> {
+    let courses = course_cache.get_all_courses().await;
+    let stats = cache.get_or_compute(&db, &courses, STATS_TTL).await?;
+    Ok(Json(stats))
 }

--- a/packages/server/src/core/mod.rs
+++ b/packages/server/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod degree_status;
 pub mod messages;
 pub mod parser;
 pub mod parser_v2;
+pub mod stats;
 pub mod types;
 
 pub mod catalog_validations;

--- a/packages/server/src/core/stats/mod.rs
+++ b/packages/server/src/core/stats/mod.rs
@@ -590,10 +590,7 @@ fn build_pipeline(now_ms: i64) -> Vec<bson::Document> {
 impl DashboardStats {
     /// Run the aggregation against `Users` and shape the result, enriching course
     /// ids with names from the supplied course map (taken from the in-memory cache).
-    pub async fn compute(
-        db: &Db,
-        courses: &HashMap<CourseId, Course>,
-    ) -> Result<Self, AppError> {
+    pub async fn compute(db: &Db, courses: &HashMap<CourseId, Course>) -> Result<Self, AppError> {
         let now_ms = bson::DateTime::now().timestamp_millis();
         let pipeline = build_pipeline(now_ms);
         let mut results: Vec<FacetResult> = db.aggregate("Users", pipeline).await?;
@@ -691,7 +688,7 @@ impl DashboardStats {
             .collect();
         // Merge duplicate "Unknown" year labels (absent + year 0 both map there).
         by_catalog_year = merge_labels(by_catalog_year);
-        by_catalog_year.sort_by(|a, b| b.value.cmp(&a.value));
+        by_catalog_year.sort_by_key(|b| std::cmp::Reverse(b.value));
 
         let feature = f.feature_adoption.into_iter().next();
         let dark_mode = feature.as_ref().map(|x| x.dark_mode).unwrap_or(0);
@@ -736,7 +733,13 @@ impl DashboardStats {
                 let start_year = s.key.start_year?;
                 let order_key = start_year * 3 + season_order(&season);
                 let label = format!("{} {}", season_label(&season), start_year);
-                Some((order_key, CountBucket { label, value: s.count }))
+                Some((
+                    order_key,
+                    CountBucket {
+                        label,
+                        value: s.count,
+                    },
+                ))
             })
             .collect();
         per_semester.sort_by_key(|(k, _)| *k);
@@ -832,8 +835,10 @@ impl DashboardStats {
         hardest_courses.truncate(HARDEST_COURSES_N);
 
         // Best / worst by average grade (only courses that have a numeric average).
-        let mut by_avg: Vec<CourseStat> =
-            graded.into_iter().filter(|c| c.average_grade.is_some()).collect();
+        let mut by_avg: Vec<CourseStat> = graded
+            .into_iter()
+            .filter(|c| c.average_grade.is_some())
+            .collect();
         by_avg.sort_by(|a, b| {
             b.average_grade
                 .unwrap_or(f64::MIN)
@@ -842,8 +847,12 @@ impl DashboardStats {
         }); // highest average first
         let best_average_courses: Vec<CourseStat> =
             by_avg.iter().take(HARDEST_COURSES_N).cloned().collect();
-        let worst_average_courses: Vec<CourseStat> =
-            by_avg.iter().rev().take(HARDEST_COURSES_N).cloned().collect();
+        let worst_average_courses: Vec<CourseStat> = by_avg
+            .iter()
+            .rev()
+            .take(HARDEST_COURSES_N)
+            .cloned()
+            .collect();
 
         let mut bank_completion: Vec<BankCompletionStat> = f
             .bank_completion
@@ -930,7 +939,7 @@ fn labeled_from_group(groups: Vec<GroupCount>, null_label: &str) -> Vec<CountBuc
         })
         .collect();
     out = merge_labels(out);
-    out.sort_by(|a, b| b.value.cmp(&a.value));
+    out.sort_by_key(|b| std::cmp::Reverse(b.value));
     out
 }
 

--- a/packages/server/src/core/stats/mod.rs
+++ b/packages/server/src/core/stats/mod.rs
@@ -1,0 +1,989 @@
+//! Admin BI dashboard statistics.
+//!
+//! One MongoDB `$facet` aggregation over the `Users` collection produces every
+//! metric the dashboard needs in a single round trip, projected server-side so we
+//! never deserialize the heavy per-user `degree_status` into Rust. The result is
+//! shaped into a single [`DashboardStats`] JSON object. Course ids in the academic
+//! facets are enriched with human-readable names from the in-memory course cache
+//! *after* aggregation (no `$lookup`). A short-TTL [`StatsCache`] memoizes the
+//! result so rapid dashboard reloads don't re-scan the collection.
+//!
+//! ## Data-shape notes (must match the BSON, not the Rust enum names)
+//! - `User._id` is the Google `sub` string; there is no email/PII.
+//! - `last_seen` is an `Option<bson::DateTime>`; absent until first login.
+//! - Faculty lives at `details.catalog.faculty` and is a *string* of the serde
+//!   variant name (`"ComputerScience"`, `"Unknown"`, …); the whole `catalog`
+//!   object is absent until onboarding, hence a `None`/`"Unknown"` bucket.
+//! - `CourseState`/`Grade` serialize to Hebrew strings. Pass = numeric >= 55 OR
+//!   `"עבר"` OR an exemption string; fail = `"נכשל"` OR numeric < 55.
+//! - A course id is stored at `course_statuses[].course._id` (serde rename).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bson::doc;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::db::Db;
+use crate::error::AppError;
+use crate::resources::course::{Course, CourseId};
+
+/// How long a computed snapshot is served before the pipeline re-runs.
+pub const STATS_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// GPA histogram bucket edges (lower-inclusive, upper-exclusive except the last).
+/// Buckets: [0,55), [55,65), [65,75), [75,85), [85,95), [95,100].
+const GPA_BUCKETS: [(f64, f64); 6] = [
+    (0.0, 55.0),
+    (55.0, 65.0),
+    (65.0, 75.0),
+    (75.0, 85.0),
+    (85.0, 95.0),
+    (95.0, 100.1),
+];
+
+/// Number of top courses to surface in the "most-taken" panel.
+const TOP_COURSES_N: i64 = 15;
+/// Number of hardest courses to surface (after a minimum-takers floor).
+const HARDEST_COURSES_N: usize = 15;
+/// Minimum number of takers before a course is eligible for the hardest-courses
+/// ranking, so a single failed one-off doesn't dominate.
+const HARDEST_MIN_TAKERS: i64 = 5;
+
+// ---------------------------------------------------------------------------
+// Public output types — these field names are the frontend contract.
+// ---------------------------------------------------------------------------
+
+//
+// NOTE: these structs serialize with serde's default (their fields are already
+// snake_case), which is exactly the frontend `AdminStats` contract. Do NOT add
+// `#[serde(rename_all = "camelCase")]` here — that would break the contract.
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DashboardStats {
+    pub overview: Overview,
+    pub activity: Activity,
+    pub population: Population,
+    pub funnel: Funnel,
+    pub academic: Academic,
+    /// ISO-8601 (RFC 3339) timestamp of when this snapshot was computed.
+    pub generated_at: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Overview {
+    pub total_users: i64,
+    /// Distinct users seen within the last 1 / 7 / 30 days.
+    pub dau: i64,
+    pub wau: i64,
+    pub mau: i64,
+    /// DAU/MAU stickiness, a fraction in [0, 1]. 0.0 when MAU is 0.
+    pub stickiness: f64,
+    /// Count of users who completed onboarding (have a catalog).
+    pub onboarded: i64,
+    /// Count of users who imported a grade sheet (non-empty course_statuses).
+    pub imported_grades: i64,
+    /// Count of users with a computed degree status (non-empty bank requirements).
+    pub computed_status: i64,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Activity {
+    /// `last_seen` within the last 7 days.
+    pub active: i64,
+    /// `last_seen` between 7 and 30 days ago.
+    pub dormant: i64,
+    /// `last_seen` older than 30 days, or never logged in.
+    pub inactive: i64,
+    /// Last-active proxy heatmap: 7 rows (Sun..Sat) x 24 cols (hour 0..23) in
+    /// Israel local time (Asia/Jerusalem, DST-aware).
+    /// Derived from one timestamp per user; a proxy, not per-action engagement.
+    pub last_active_heatmap: Vec<Vec<i64>>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Population {
+    /// Users by faculty. Always includes a `"Unknown"` bucket for users with no
+    /// catalog (or a catalog whose faculty is `Unknown`).
+    pub by_faculty: Vec<CountBucket>,
+    /// Users by catalog/track name (the catalog `name`). `"None"` = no catalog.
+    pub by_catalog: Vec<CountBucket>,
+    /// Users by catalog year. Year `0`/absent rolls into a `"Unknown"` label.
+    pub by_catalog_year: Vec<CountBucket>,
+    /// Feature adoption counts as labeled buckets (Hebrew labels).
+    pub adoption: Vec<CountBucket>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Funnel {
+    /// All users (signed in at least once to exist in the collection).
+    pub signed_in: i64,
+    /// Picked a catalog.
+    pub picked_catalog: i64,
+    /// Imported a grade sheet (non-empty course_statuses).
+    pub imported_grades: i64,
+    /// Computed degree status (non-empty bank requirements).
+    pub computed_status: i64,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Academic {
+    /// Course-statuses counted per academic semester, ordered chronologically.
+    pub courses_per_semester: Vec<CountBucket>,
+    /// Top-N most-taken courses, with enriched names.
+    pub most_taken_courses: Vec<CourseStat>,
+    /// One data point per student's weighted GPA, bucketed into a histogram.
+    pub gpa_distribution: Vec<CountBucket>,
+    /// Hardest courses by avg numeric grade / fail rate / repeats.
+    pub hardest_courses: Vec<CourseStat>,
+    /// Highest-average courses (min graded-takers floor applied).
+    pub best_average_courses: Vec<CourseStat>,
+    /// Lowest-average courses (min graded-takers floor applied).
+    pub worst_average_courses: Vec<CourseStat>,
+    /// Per requirement-bank completion rates.
+    pub bank_completion: Vec<BankCompletionStat>,
+}
+
+/// A `{ label, value }` pair for categorical bar/pie series.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct CountBucket {
+    pub label: String,
+    pub value: i64,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct CourseStat {
+    pub course_id: String,
+    /// Enriched from the course cache; falls back to the id when unknown.
+    pub course_name: String,
+    pub count: i64,
+    /// Average numeric grade across graded attempts. Omitted when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average_grade: Option<f64>,
+    /// Fail rate over graded attempts, a fraction in [0, 1]. Omitted when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_rate: Option<f64>,
+    /// Total repeats recorded across all takers. Omitted when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub times_repeated: Option<i64>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct BankCompletionStat {
+    pub bank_name: String,
+    /// completed/total, a fraction in [0, 1].
+    pub completion_rate: f64,
+    /// How many of those have it completed.
+    pub completed: i64,
+    /// How many users have this bank in their computed status.
+    pub total: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Raw aggregation result (one document out of the single `$facet`).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct FacetResult {
+    #[serde(default)]
+    total: Vec<CountDoc>,
+    #[serde(default)]
+    dau: Vec<CountDoc>,
+    #[serde(default)]
+    wau: Vec<CountDoc>,
+    #[serde(default)]
+    mau: Vec<CountDoc>,
+    #[serde(default)]
+    onboarded: Vec<CountDoc>,
+    #[serde(default)]
+    imported: Vec<CountDoc>,
+    #[serde(default)]
+    computed: Vec<CountDoc>,
+    #[serde(default)]
+    recency: Vec<RecencyDoc>,
+    #[serde(default)]
+    heatmap: Vec<HeatmapDoc>,
+    #[serde(default)]
+    by_faculty: Vec<GroupCount>,
+    #[serde(default)]
+    by_catalog: Vec<GroupCount>,
+    #[serde(default)]
+    by_catalog_year: Vec<GroupCountNum>,
+    #[serde(default)]
+    feature_adoption: Vec<FeatureDoc>,
+    #[serde(default)]
+    courses_per_semester: Vec<SemesterDoc>,
+    #[serde(default)]
+    top_courses: Vec<CourseAggDoc>,
+    #[serde(default)]
+    gpa: Vec<GpaDoc>,
+    #[serde(default)]
+    hardest: Vec<HardestDoc>,
+    #[serde(default)]
+    bank_completion: Vec<BankDoc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CountDoc {
+    #[serde(default)]
+    count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RecencyDoc {
+    #[serde(rename = "_id")]
+    bucket: String,
+    #[serde(default)]
+    count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct HeatmapDoc {
+    #[serde(rename = "_id")]
+    key: HeatmapKey,
+    #[serde(default)]
+    count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct HeatmapKey {
+    #[serde(default)]
+    dow: i32,
+    #[serde(default)]
+    hour: i32,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroupCount {
+    #[serde(rename = "_id")]
+    label: Option<String>,
+    #[serde(default)]
+    count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroupCountNum {
+    #[serde(rename = "_id")]
+    label: Option<i64>,
+    #[serde(default)]
+    count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct FeatureDoc {
+    #[serde(default)]
+    dark_mode: i64,
+    #[serde(default)]
+    custom_palette: i64,
+    #[serde(default)]
+    timetable_drafts: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SemesterDoc {
+    #[serde(rename = "_id")]
+    key: SemesterKey,
+    #[serde(default)]
+    count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SemesterKey {
+    season: Option<String>,
+    start_year: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CourseAggDoc {
+    #[serde(rename = "_id")]
+    course_id: Option<String>,
+    #[serde(default)]
+    count: i64,
+    /// Course name embedded in the student record (via `$first`).
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GpaDoc {
+    #[serde(rename = "_id")]
+    bucket: i32,
+    #[serde(default)]
+    count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct HardestDoc {
+    #[serde(rename = "_id")]
+    course_id: Option<String>,
+    /// Course name embedded in the student record (via `$first`).
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    takers: i64,
+    #[serde(default)]
+    avg_grade: Option<f64>,
+    #[serde(default)]
+    fails: i64,
+    #[serde(default)]
+    graded: i64,
+    #[serde(default)]
+    total_repeats: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct BankDoc {
+    #[serde(rename = "_id")]
+    bank_name: Option<String>,
+    #[serde(default)]
+    total: i64,
+    #[serde(default)]
+    completed: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline construction.
+// ---------------------------------------------------------------------------
+
+/// Builds the single `$facet` pipeline over `Users`. `now_ms` is the current time
+/// in epoch milliseconds (injected so tests can pin a clock).
+fn build_pipeline(now_ms: i64) -> Vec<bson::Document> {
+    let day_ms: i64 = 24 * 60 * 60 * 1000;
+    let one_day_ago = bson::DateTime::from_millis(now_ms - day_ms);
+    let seven_days_ago = bson::DateTime::from_millis(now_ms - 7 * day_ms);
+    let thirty_days_ago = bson::DateTime::from_millis(now_ms - 30 * day_ms);
+
+    // A numeric-grade detector: a grade string that parses as a double. MongoDB's
+    // `$convert` with `onError` returns the fallback when the string isn't numeric.
+    // Reused inside the academic facets via `$let`.
+    let numeric_grade = doc! {
+        "$convert": { "input": "$$g", "to": "double", "onError": bson::Bson::Null, "onNull": bson::Bson::Null }
+    };
+
+    vec![doc! {
+        "$facet": {
+            // --- Overview counts -------------------------------------------------
+            "total": [ { "$count": "count" } ],
+            "dau": [
+                { "$match": { "last_seen": { "$gte": one_day_ago } } },
+                { "$count": "count" }
+            ],
+            "wau": [
+                { "$match": { "last_seen": { "$gte": seven_days_ago } } },
+                { "$count": "count" }
+            ],
+            "mau": [
+                { "$match": { "last_seen": { "$gte": thirty_days_ago } } },
+                { "$count": "count" }
+            ],
+            "onboarded": [
+                { "$match": { "details.catalog": { "$ne": bson::Bson::Null } } },
+                { "$count": "count" }
+            ],
+            "imported": [
+                { "$match": { "details.degree_status.course_statuses.0": { "$exists": true } } },
+                { "$count": "count" }
+            ],
+            "computed": [
+                { "$match": { "details.degree_status.course_bank_requirements.0": { "$exists": true } } },
+                { "$count": "count" }
+            ],
+
+            // --- Activity recency buckets ---------------------------------------
+            "recency": [
+                { "$project": {
+                    "bucket": {
+                        "$switch": {
+                            "branches": [
+                                { "case": { "$eq": [ { "$type": "$last_seen" }, "missing" ] }, "then": "never" },
+                                { "case": { "$eq": [ "$last_seen", bson::Bson::Null ] }, "then": "never" },
+                                { "case": { "$gte": [ "$last_seen", seven_days_ago ] }, "then": "active7d" },
+                                { "case": { "$gte": [ "$last_seen", thirty_days_ago ] }, "then": "dormant7to30d" }
+                            ],
+                            "default": "inactive30d_plus"
+                        }
+                    }
+                } },
+                { "$group": { "_id": "$bucket", "count": { "$sum": 1 } } }
+            ],
+
+            // --- Last-seen day-of-week x hour heatmap (Israel local time) -------
+            "heatmap": [
+                // `$ne: null` in Mongo also excludes the missing field, so this
+                // keeps only users that have actually logged in.
+                { "$match": { "last_seen": { "$ne": bson::Bson::Null } } },
+                { "$group": {
+                    "_id": {
+                        // Mongo $dayOfWeek: 1 (Sun) .. 7 (Sat) -> 0..6. Bucketed in
+                        // Israel local time (Asia/Jerusalem, DST-aware) so "when"
+                        // reflects the students' actual clock.
+                        "dow": { "$subtract": [ { "$dayOfWeek": { "date": "$last_seen", "timezone": "Asia/Jerusalem" } }, 1 ] },
+                        "hour": { "$hour": { "date": "$last_seen", "timezone": "Asia/Jerusalem" } }
+                    },
+                    "count": { "$sum": 1 }
+                } }
+            ],
+
+            // --- Population: faculty / catalog / year ---------------------------
+            "by_faculty": [
+                { "$group": {
+                    "_id": { "$ifNull": [ "$details.catalog.faculty", "Unknown" ] },
+                    "count": { "$sum": 1 }
+                } }
+            ],
+            "by_catalog": [
+                { "$group": {
+                    "_id": { "$ifNull": [ "$details.catalog.name", bson::Bson::Null ] },
+                    "count": { "$sum": 1 }
+                } }
+            ],
+            "by_catalog_year": [
+                { "$group": {
+                    "_id": "$details.catalog.year",
+                    "count": { "$sum": 1 }
+                } }
+            ],
+
+            // --- Feature adoption ------------------------------------------------
+            "feature_adoption": [
+                { "$group": {
+                    "_id": bson::Bson::Null,
+                    "dark_mode": { "$sum": { "$cond": [ { "$eq": [ "$settings.dark_mode", true ] }, 1, 0 ] } },
+                    "custom_palette": { "$sum": { "$cond": [
+                        { "$and": [
+                            { "$ne": [ { "$type": "$settings.palette" }, "missing" ] },
+                            { "$ne": [ "$settings.palette", bson::Bson::Null ] }
+                        ] }, 1, 0 ] } },
+                    "timetable_drafts": { "$sum": { "$cond": [
+                        { "$gt": [ { "$size": { "$ifNull": [ "$timetable.drafts", [] ] } }, 0 ] }, 1, 0 ] } }
+                } }
+            ],
+
+            // --- Academic: courses per semester ---------------------------------
+            "courses_per_semester": [
+                { "$unwind": "$details.degree_status.course_statuses" },
+                { "$match": { "details.degree_status.course_statuses.semester": { "$ne": bson::Bson::Null } } },
+                { "$group": {
+                    "_id": {
+                        "season": "$details.degree_status.course_statuses.semester.season",
+                        "start_year": "$details.degree_status.course_statuses.semester.start_year"
+                    },
+                    "count": { "$sum": 1 }
+                } }
+            ],
+
+            // --- Academic: most-taken courses -----------------------------------
+            "top_courses": [
+                { "$unwind": "$details.degree_status.course_statuses" },
+                { "$group": {
+                    "_id": "$details.degree_status.course_statuses.course._id",
+                    "count": { "$sum": 1 },
+                    "name": { "$first": "$details.degree_status.course_statuses.course.name" }
+                } },
+                { "$sort": { "count": -1 } },
+                { "$limit": TOP_COURSES_N }
+            ],
+
+            // --- Academic: per-student weighted GPA -> histogram bucket ---------
+            "gpa": [
+                { "$unwind": "$details.degree_status.course_statuses" },
+                { "$project": {
+                    "_id": 1,
+                    "credit": { "$ifNull": [ "$details.degree_status.course_statuses.course.credit", 0 ] },
+                    "numeric": { "$let": {
+                        "vars": { "g": "$details.degree_status.course_statuses.grade" },
+                        "in": numeric_grade.clone()
+                    } }
+                } },
+                // Keep only numeric, credit-bearing attempts for the weighted average.
+                { "$match": { "numeric": { "$ne": bson::Bson::Null }, "credit": { "$gt": 0 } } },
+                { "$group": {
+                    "_id": "$_id",
+                    "weighted": { "$sum": { "$multiply": [ "$numeric", "$credit" ] } },
+                    "credits": { "$sum": "$credit" }
+                } },
+                { "$match": { "credits": { "$gt": 0 } } },
+                { "$project": { "gpa": { "$divide": [ "$weighted", "$credits" ] } } },
+                { "$bucket": {
+                    "groupBy": "$gpa",
+                    "boundaries": [ 0.0, 55.0, 65.0, 75.0, 85.0, 95.0, 101.0 ],
+                    "default": -1,
+                    "output": { "count": { "$sum": 1 } }
+                } },
+                // Re-map the bucket boundary lower-bound to a 0..5 index for stable output.
+                { "$project": {
+                    "_id": { "$switch": {
+                        "branches": [
+                            { "case": { "$eq": [ "$_id", 0.0 ] }, "then": 0 },
+                            { "case": { "$eq": [ "$_id", 55.0 ] }, "then": 1 },
+                            { "case": { "$eq": [ "$_id", 65.0 ] }, "then": 2 },
+                            { "case": { "$eq": [ "$_id", 75.0 ] }, "then": 3 },
+                            { "case": { "$eq": [ "$_id", 85.0 ] }, "then": 4 },
+                            { "case": { "$eq": [ "$_id", 95.0 ] }, "then": 5 }
+                        ],
+                        "default": -1
+                    } },
+                    "count": 1
+                } }
+            ],
+
+            // --- Academic: hardest courses --------------------------------------
+            "hardest": [
+                { "$unwind": "$details.degree_status.course_statuses" },
+                { "$project": {
+                    "course_id": "$details.degree_status.course_statuses.course._id",
+                    "name": "$details.degree_status.course_statuses.course.name",
+                    "repeats": { "$ifNull": [ "$details.degree_status.course_statuses.times_repeated", 0 ] },
+                    "grade": "$details.degree_status.course_statuses.grade",
+                    "numeric": { "$let": {
+                        "vars": { "g": "$details.degree_status.course_statuses.grade" },
+                        "in": numeric_grade.clone()
+                    } }
+                } },
+                { "$project": {
+                    "course_id": 1,
+                    "name": 1,
+                    "repeats": 1,
+                    "numeric": 1,
+                    // graded = has a numeric grade OR an explicit pass/fail binary.
+                    "is_graded": { "$or": [
+                        { "$ne": [ "$numeric", bson::Bson::Null ] },
+                        { "$in": [ "$grade", [ "עבר", "נכשל" ] ] }
+                    ] },
+                    "is_fail": { "$or": [
+                        { "$eq": [ "$grade", "נכשל" ] },
+                        { "$and": [ { "$ne": [ "$numeric", bson::Bson::Null ] }, { "$lt": [ "$numeric", 55 ] } ] }
+                    ] }
+                } },
+                { "$group": {
+                    "_id": "$course_id",
+                    "name": { "$first": "$name" },
+                    "takers": { "$sum": 1 },
+                    "graded": { "$sum": { "$cond": [ "$is_graded", 1, 0 ] } },
+                    "fails": { "$sum": { "$cond": [ "$is_fail", 1, 0 ] } },
+                    "avg_grade": { "$avg": "$numeric" },
+                    "total_repeats": { "$sum": "$repeats" }
+                } },
+                { "$match": { "graded": { "$gte": HARDEST_MIN_TAKERS } } }
+            ],
+
+            // --- Academic: requirement-bank completion --------------------------
+            "bank_completion": [
+                { "$unwind": "$details.degree_status.course_bank_requirements" },
+                { "$group": {
+                    "_id": "$details.degree_status.course_bank_requirements.course_bank_name",
+                    "total": { "$sum": 1 },
+                    "completed": { "$sum": { "$cond": [
+                        { "$eq": [ "$details.degree_status.course_bank_requirements.completed", true ] }, 1, 0 ] } }
+                } }
+            ]
+        }
+    }]
+}
+
+// ---------------------------------------------------------------------------
+// Compute: run pipeline + enrich.
+// ---------------------------------------------------------------------------
+
+impl DashboardStats {
+    /// Run the aggregation against `Users` and shape the result, enriching course
+    /// ids with names from the supplied course map (taken from the in-memory cache).
+    pub async fn compute(
+        db: &Db,
+        courses: &HashMap<CourseId, Course>,
+    ) -> Result<Self, AppError> {
+        let now_ms = bson::DateTime::now().timestamp_millis();
+        let pipeline = build_pipeline(now_ms);
+        let mut results: Vec<FacetResult> = db.aggregate("Users", pipeline).await?;
+        let facet = results.pop().unwrap_or(FacetResult {
+            total: vec![],
+            dau: vec![],
+            wau: vec![],
+            mau: vec![],
+            onboarded: vec![],
+            imported: vec![],
+            computed: vec![],
+            recency: vec![],
+            heatmap: vec![],
+            by_faculty: vec![],
+            by_catalog: vec![],
+            by_catalog_year: vec![],
+            feature_adoption: vec![],
+            courses_per_semester: vec![],
+            top_courses: vec![],
+            gpa: vec![],
+            hardest: vec![],
+            bank_completion: vec![],
+        });
+        Ok(Self::from_facet(facet, courses))
+    }
+
+    fn from_facet(f: FacetResult, courses: &HashMap<CourseId, Course>) -> Self {
+        let count_of = |v: &[CountDoc]| v.first().map(|c| c.count).unwrap_or(0);
+
+        let total_users = count_of(&f.total);
+        let dau = count_of(&f.dau);
+        let wau = count_of(&f.wau);
+        let mau = count_of(&f.mau);
+        let onboarded = count_of(&f.onboarded);
+        let imported = count_of(&f.imported);
+        let computed_n = count_of(&f.computed);
+
+        let overview = Overview {
+            total_users,
+            dau,
+            wau,
+            mau,
+            stickiness: if mau == 0 {
+                0.0
+            } else {
+                (dau as f64) / (mau as f64)
+            },
+            onboarded,
+            imported_grades: imported,
+            computed_status: computed_n,
+        };
+
+        // Recency buckets. The frontend collapses these into 3:
+        //   active = active7d; dormant = dormant7to30d; inactive = inactive30d_plus + never.
+        let mut active7d = 0;
+        let mut dormant7to30d = 0;
+        let mut inactive30d_plus = 0;
+        let mut never = 0;
+        for r in &f.recency {
+            match r.bucket.as_str() {
+                "active7d" => active7d = r.count,
+                "dormant7to30d" => dormant7to30d = r.count,
+                "inactive30d_plus" => inactive30d_plus = r.count,
+                "never" => never = r.count,
+                _ => {}
+            }
+        }
+        // 7 rows (Sun..Sat) x 24 cols.
+        let mut last_active_heatmap = vec![vec![0i64; 24]; 7];
+        for h in &f.heatmap {
+            let dow = h.key.dow.clamp(0, 6) as usize;
+            let hour = h.key.hour.clamp(0, 23) as usize;
+            last_active_heatmap[dow][hour] += h.count;
+        }
+        let activity = Activity {
+            active: active7d,
+            dormant: dormant7to30d,
+            inactive: inactive30d_plus + never,
+            last_active_heatmap,
+        };
+
+        // Population.
+        let by_faculty = labeled_from_group(f.by_faculty, "Unknown");
+        let by_catalog = labeled_from_group(f.by_catalog, "None");
+        let mut by_catalog_year: Vec<CountBucket> = f
+            .by_catalog_year
+            .into_iter()
+            .map(|g| CountBucket {
+                label: match g.label {
+                    Some(y) if y > 0 => y.to_string(),
+                    _ => "Unknown".to_string(),
+                },
+                value: g.count,
+            })
+            .collect();
+        // Merge duplicate "Unknown" year labels (absent + year 0 both map there).
+        by_catalog_year = merge_labels(by_catalog_year);
+        by_catalog_year.sort_by(|a, b| b.value.cmp(&a.value));
+
+        let feature = f.feature_adoption.into_iter().next();
+        let dark_mode = feature.as_ref().map(|x| x.dark_mode).unwrap_or(0);
+        let custom_palette = feature.as_ref().map(|x| x.custom_palette).unwrap_or(0);
+        let timetable_drafts = feature.as_ref().map(|x| x.timetable_drafts).unwrap_or(0);
+        let adoption = vec![
+            CountBucket {
+                label: "מצב כהה".to_string(),
+                value: dark_mode,
+            },
+            CountBucket {
+                label: "פלטה מותאמת".to_string(),
+                value: custom_palette,
+            },
+            CountBucket {
+                label: "מערכת שעות".to_string(),
+                value: timetable_drafts,
+            },
+        ];
+
+        let population = Population {
+            by_faculty,
+            by_catalog,
+            by_catalog_year,
+            adoption,
+        };
+
+        let funnel = Funnel {
+            signed_in: total_users,
+            picked_catalog: onboarded,
+            imported_grades: imported,
+            computed_status: computed_n,
+        };
+
+        // Academic: courses per semester, sorted by order_key, emitted as labeled
+        // buckets with a Hebrew "<season> <start_year>" label.
+        let mut per_semester: Vec<(i32, CountBucket)> = f
+            .courses_per_semester
+            .into_iter()
+            .filter_map(|s| {
+                let season = s.key.season?;
+                let start_year = s.key.start_year?;
+                let order_key = start_year * 3 + season_order(&season);
+                let label = format!("{} {}", season_label(&season), start_year);
+                Some((order_key, CountBucket { label, value: s.count }))
+            })
+            .collect();
+        per_semester.sort_by_key(|(k, _)| *k);
+        let courses_per_semester: Vec<CountBucket> =
+            per_semester.into_iter().map(|(_, b)| b).collect();
+
+        // Prefer the course name embedded in the student's record (present for any
+        // course a student has taken), then the in-memory course cache, then the id.
+        let resolve = |doc_name: Option<&str>, id: &str| -> String {
+            match doc_name.map(str::trim).filter(|s| !s.is_empty()) {
+                Some(n) => n.to_string(),
+                None => courses
+                    .get(id)
+                    .map(|c| c.name.clone())
+                    .unwrap_or_else(|| id.to_string()),
+            }
+        };
+
+        let most_taken_courses: Vec<CourseStat> = f
+            .top_courses
+            .into_iter()
+            .filter_map(|c| {
+                let course_id = c.course_id?;
+                Some(CourseStat {
+                    course_name: resolve(c.name.as_deref(), &course_id),
+                    course_id,
+                    count: c.count,
+                    average_grade: None,
+                    fail_rate: None,
+                    times_repeated: None,
+                })
+            })
+            .collect();
+
+        // GPA distribution: map bucket index -> label; ensure all buckets present,
+        // in ascending order.
+        let mut gpa_counts = [0i64; GPA_BUCKETS.len()];
+        for g in &f.gpa {
+            if g.bucket >= 0 && (g.bucket as usize) < GPA_BUCKETS.len() {
+                gpa_counts[g.bucket as usize] += g.count;
+            }
+        }
+        let gpa_distribution: Vec<CountBucket> = (0..GPA_BUCKETS.len())
+            .map(|i| CountBucket {
+                label: gpa_label(i),
+                value: gpa_counts[i],
+            })
+            .collect();
+
+        // All courses with >= HARDEST_MIN_TAKERS graded takers, as CourseStat. The
+        // hardest / best-average / worst-average rankings are all derived from this
+        // same set (so a one-off outlier can't dominate any of them).
+        let graded: Vec<CourseStat> = f
+            .hardest
+            .into_iter()
+            .filter_map(|h| {
+                let course_id = h.course_id?;
+                let fail_rate = if h.graded == 0 {
+                    0.0
+                } else {
+                    (h.fails as f64) / (h.graded as f64)
+                };
+                Some(CourseStat {
+                    course_name: resolve(h.name.as_deref(), &course_id),
+                    course_id,
+                    count: h.takers,
+                    average_grade: h.avg_grade,
+                    fail_rate: Some(fail_rate),
+                    times_repeated: Some(h.total_repeats),
+                })
+            })
+            .collect();
+
+        // Hardest: by fail rate desc, then avg grade asc, then repeats desc.
+        let mut hardest_courses = graded.clone();
+        hardest_courses.sort_by(|a, b| {
+            b.fail_rate
+                .unwrap_or(0.0)
+                .partial_cmp(&a.fail_rate.unwrap_or(0.0))
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| {
+                    a.average_grade
+                        .unwrap_or(f64::MAX)
+                        .partial_cmp(&b.average_grade.unwrap_or(f64::MAX))
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .then_with(|| {
+                    b.times_repeated
+                        .unwrap_or(0)
+                        .cmp(&a.times_repeated.unwrap_or(0))
+                })
+        });
+        hardest_courses.truncate(HARDEST_COURSES_N);
+
+        // Best / worst by average grade (only courses that have a numeric average).
+        let mut by_avg: Vec<CourseStat> =
+            graded.into_iter().filter(|c| c.average_grade.is_some()).collect();
+        by_avg.sort_by(|a, b| {
+            b.average_grade
+                .unwrap_or(f64::MIN)
+                .partial_cmp(&a.average_grade.unwrap_or(f64::MIN))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }); // highest average first
+        let best_average_courses: Vec<CourseStat> =
+            by_avg.iter().take(HARDEST_COURSES_N).cloned().collect();
+        let worst_average_courses: Vec<CourseStat> =
+            by_avg.iter().rev().take(HARDEST_COURSES_N).cloned().collect();
+
+        let mut bank_completion: Vec<BankCompletionStat> = f
+            .bank_completion
+            .into_iter()
+            .filter_map(|b| {
+                let bank_name = b.bank_name?;
+                let completion_rate = if b.total == 0 {
+                    0.0
+                } else {
+                    (b.completed as f64) / (b.total as f64)
+                };
+                Some(BankCompletionStat {
+                    bank_name,
+                    completion_rate,
+                    completed: b.completed,
+                    total: b.total,
+                })
+            })
+            .collect();
+        bank_completion.sort_by(|a, b| {
+            a.completion_rate
+                .partial_cmp(&b.completion_rate)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let academic = Academic {
+            courses_per_semester,
+            most_taken_courses,
+            gpa_distribution,
+            hardest_courses,
+            best_average_courses,
+            worst_average_courses,
+            bank_completion,
+        };
+
+        DashboardStats {
+            overview,
+            activity,
+            population,
+            funnel,
+            academic,
+            generated_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+/// Maps a serialized `SemesterSeason` string to its Hebrew display label.
+fn season_label(season: &str) -> &'static str {
+    match season {
+        "winter" => "חורף",
+        "spring" => "אביב",
+        "summer" => "קיץ",
+        _ => "חורף",
+    }
+}
+
+/// Maps a serialized `SemesterSeason` string to its `order` (winter/spring/summer = 0/1/2).
+fn season_order(season: &str) -> i32 {
+    match season {
+        "winter" => 0,
+        "spring" => 1,
+        "summer" => 2,
+        _ => 0,
+    }
+}
+
+fn gpa_label(i: usize) -> String {
+    match i {
+        0 => "0-54".to_string(),
+        1 => "55-64".to_string(),
+        2 => "65-74".to_string(),
+        3 => "75-84".to_string(),
+        4 => "85-94".to_string(),
+        _ => "95-100".to_string(),
+    }
+}
+
+fn labeled_from_group(groups: Vec<GroupCount>, null_label: &str) -> Vec<CountBucket> {
+    let mut out: Vec<CountBucket> = groups
+        .into_iter()
+        .map(|g| CountBucket {
+            label: g.label.unwrap_or_else(|| null_label.to_string()),
+            value: g.count,
+        })
+        .collect();
+    out = merge_labels(out);
+    out.sort_by(|a, b| b.value.cmp(&a.value));
+    out
+}
+
+/// Collapses duplicate labels by summing their values (preserving first-seen order).
+fn merge_labels(items: Vec<CountBucket>) -> Vec<CountBucket> {
+    let mut order: Vec<String> = Vec::new();
+    let mut map: HashMap<String, i64> = HashMap::new();
+    for item in items {
+        if !map.contains_key(&item.label) {
+            order.push(item.label.clone());
+        }
+        *map.entry(item.label).or_insert(0) += item.value;
+    }
+    order
+        .into_iter()
+        .map(|label| {
+            let value = map[&label];
+            CountBucket { label, value }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// TTL cache.
+// ---------------------------------------------------------------------------
+
+/// In-memory, short-TTL cache for the computed dashboard stats. Cheap to clone
+/// (`Arc` inside), so it can live as an axum `Extension`.
+#[derive(Clone, Default)]
+pub struct StatsCache(Arc<RwLock<Option<(Instant, DashboardStats)>>>);
+
+impl StatsCache {
+    /// Returns a cached snapshot when one exists and is younger than `ttl`,
+    /// otherwise recomputes via the aggregation and stores it.
+    pub async fn get_or_compute(
+        &self,
+        db: &Db,
+        courses: &HashMap<CourseId, Course>,
+        ttl: Duration,
+    ) -> Result<DashboardStats, AppError> {
+        // Fast path: a fresh value already cached.
+        if let Some((at, stats)) = self.0.read().await.as_ref() {
+            if at.elapsed() < ttl {
+                return Ok(stats.clone());
+            }
+        }
+        // Slow path: compute and store. A concurrent caller may also compute; the
+        // last writer wins, which is fine for an idempotent read-only snapshot.
+        let stats = DashboardStats::compute(db, courses).await?;
+        *self.0.write().await = Some((Instant::now(), stats.clone()));
+        Ok(stats)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/packages/server/src/core/stats/tests.rs
+++ b/packages/server/src/core/stats/tests.rs
@@ -299,8 +299,7 @@ async fn compute_against_live_db_when_available() {
     assert!(stats.overview.wau <= stats.overview.mau);
     assert!(stats.overview.mau <= stats.overview.total_users);
     // The 3 recency buckets partition all users.
-    let recency_sum =
-        stats.activity.active + stats.activity.dormant + stats.activity.inactive;
+    let recency_sum = stats.activity.active + stats.activity.dormant + stats.activity.inactive;
     assert_eq!(recency_sum, stats.overview.total_users);
     assert_eq!(stats.activity.last_active_heatmap.len(), 7);
     assert_eq!(stats.academic.gpa_distribution.len(), GPA_BUCKETS.len());

--- a/packages/server/src/core/stats/tests.rs
+++ b/packages/server/src/core/stats/tests.rs
@@ -1,0 +1,309 @@
+//! Tests for the admin BI dashboard statistics.
+//!
+//! Pure shaping logic (`from_facet`, label merging, GPA bucketing) is tested
+//! without a database. A live-DB integration test that seeds users and asserts
+//! each facet is gated behind the same `SOGRIM_URI`/`SOGRIM_PROFILE` test-env
+//! pattern used elsewhere, so the suite never blocks on a database being present.
+
+use super::*;
+
+fn courses_fixture() -> HashMap<CourseId, Course> {
+    let mut m = HashMap::new();
+    for (id, name) in [
+        ("01040031", "חשבון אינפיניטסימלי 1מ'"),
+        ("01040166", "אלגברה אמ'"),
+    ] {
+        m.insert(
+            CourseId::new(id),
+            Course {
+                id: CourseId::new(id),
+                credit: 5.0,
+                name: name.to_string(),
+                tags: None,
+            },
+        );
+    }
+    m
+}
+
+/// Builds a `FacetResult` from raw BSON exactly as the pipeline would emit it,
+/// so we test the deserialization + shaping path end to end without a DB.
+fn facet_from_bson(d: bson::Document) -> FacetResult {
+    bson::deserialize_from_document(d).expect("facet doc should deserialize")
+}
+
+#[test]
+fn overview_counts_and_stickiness() {
+    let f = facet_from_bson(bson::doc! {
+        "total": [ { "count": 100i64 } ],
+        "dau": [ { "count": 10i64 } ],
+        "wau": [ { "count": 30i64 } ],
+        "mau": [ { "count": 50i64 } ],
+        "onboarded": [ { "count": 80i64 } ],
+        "imported": [ { "count": 60i64 } ],
+        "computed": [ { "count": 40i64 } ],
+    });
+    let stats = DashboardStats::from_facet(f, &courses_fixture());
+    assert_eq!(stats.overview.total_users, 100);
+    assert_eq!(stats.overview.dau, 10);
+    assert_eq!(stats.overview.wau, 30);
+    assert_eq!(stats.overview.mau, 50);
+    // Stickiness is a fraction in [0, 1] = dau/mau.
+    assert_eq!(stats.overview.stickiness, 0.2);
+    // Overview emits raw counts (the UI divides by total itself).
+    assert_eq!(stats.overview.onboarded, 80);
+    assert_eq!(stats.overview.imported_grades, 60);
+    assert_eq!(stats.overview.computed_status, 40);
+    // generated_at is an RFC-3339 timestamp.
+    assert!(!stats.generated_at.is_empty());
+    assert!(stats.generated_at.contains('T'));
+    // Funnel mirrors the same counts.
+    assert_eq!(stats.funnel.signed_in, 100);
+    assert_eq!(stats.funnel.picked_catalog, 80);
+    assert_eq!(stats.funnel.imported_grades, 60);
+    assert_eq!(stats.funnel.computed_status, 40);
+}
+
+#[test]
+fn empty_db_is_all_zeroes_not_a_panic() {
+    let stats = DashboardStats::from_facet(facet_from_bson(bson::doc! {}), &HashMap::new());
+    assert_eq!(stats.overview.total_users, 0);
+    assert_eq!(stats.overview.onboarded, 0);
+    // Stickiness is 0.0 (not null) when mau == 0.
+    assert_eq!(stats.overview.stickiness, 0.0);
+    // The GPA distribution always has all buckets, even with no data.
+    assert_eq!(stats.academic.gpa_distribution.len(), GPA_BUCKETS.len());
+    assert!(stats.academic.gpa_distribution.iter().all(|b| b.value == 0));
+    // Heatmap is always 7x24.
+    assert_eq!(stats.activity.last_active_heatmap.len(), 7);
+    assert!(stats
+        .activity
+        .last_active_heatmap
+        .iter()
+        .all(|r| r.len() == 24));
+    // Adoption is always a 3-element labeled array.
+    assert_eq!(stats.population.adoption.len(), 3);
+}
+
+#[test]
+fn recency_collapses_to_three_buckets_and_heatmap() {
+    let f = facet_from_bson(bson::doc! {
+        "recency": [
+            { "_id": "active7d", "count": 5i64 },
+            { "_id": "dormant7to30d", "count": 3i64 },
+            { "_id": "inactive30d_plus", "count": 2i64 },
+            { "_id": "never", "count": 7i64 },
+        ],
+        "heatmap": [
+            { "_id": { "dow": 0i32, "hour": 9i32 }, "count": 4i64 },
+            { "_id": { "dow": 6i32, "hour": 23i32 }, "count": 1i64 },
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &HashMap::new());
+    assert_eq!(stats.activity.active, 5);
+    assert_eq!(stats.activity.dormant, 3);
+    // inactive = inactive30d_plus + never = 2 + 7.
+    assert_eq!(stats.activity.inactive, 9);
+    assert_eq!(stats.activity.last_active_heatmap[0][9], 4);
+    assert_eq!(stats.activity.last_active_heatmap[6][23], 1);
+}
+
+#[test]
+fn adoption_is_labeled_three_element_array() {
+    let f = facet_from_bson(bson::doc! {
+        "feature_adoption": [
+            { "_id": bson::Bson::Null, "dark_mode": 12i64, "custom_palette": 7i64, "timetable_drafts": 3i64 },
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &HashMap::new());
+    let a = &stats.population.adoption;
+    assert_eq!(a.len(), 3);
+    assert_eq!(a[0].label, "מצב כהה");
+    assert_eq!(a[0].value, 12);
+    assert_eq!(a[1].label, "פלטה מותאמת");
+    assert_eq!(a[1].value, 7);
+    assert_eq!(a[2].label, "מערכת שעות");
+    assert_eq!(a[2].value, 3);
+}
+
+#[test]
+fn faculty_catalog_and_year_buckets_merge_nulls() {
+    let f = facet_from_bson(bson::doc! {
+        "by_faculty": [
+            { "_id": "ComputerScience", "count": 10i64 },
+            { "_id": bson::Bson::Null, "count": 4i64 }, // no catalog -> Unknown
+            { "_id": "Unknown", "count": 2i64 },        // explicit Unknown faculty
+        ],
+        "by_catalog": [
+            { "_id": "מדמח תלת שנתי 2022-2023", "count": 6i64 },
+            { "_id": bson::Bson::Null, "count": 4i64 },
+        ],
+        "by_catalog_year": [
+            { "_id": 2022i64, "count": 6i64 },
+            { "_id": 0i64, "count": 1i64 },
+            { "_id": bson::Bson::Null, "count": 3i64 },
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &HashMap::new());
+    // The two Unknown faculty entries (null + explicit) merge into one.
+    let unknown = stats
+        .population
+        .by_faculty
+        .iter()
+        .find(|l| l.label == "Unknown")
+        .expect("Unknown faculty bucket present");
+    assert_eq!(unknown.value, 6);
+    // Catalog null -> "None".
+    assert!(stats
+        .population
+        .by_catalog
+        .iter()
+        .any(|l| l.label == "None" && l.value == 4));
+    // Year 0 + null merge into "Unknown" = 4.
+    let yr_unknown = stats
+        .population
+        .by_catalog_year
+        .iter()
+        .find(|l| l.label == "Unknown")
+        .expect("Unknown year bucket present");
+    assert_eq!(yr_unknown.value, 4);
+}
+
+#[test]
+fn courses_per_semester_sorted_by_order_key() {
+    let f = facet_from_bson(bson::doc! {
+        "courses_per_semester": [
+            { "_id": { "season": "spring", "start_year": 2023i32 }, "count": 8i64 },
+            { "_id": { "season": "winter", "start_year": 2023i32 }, "count": 5i64 },
+            { "_id": { "season": "winter", "start_year": 2022i32 }, "count": 3i64 },
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &HashMap::new());
+    let labels: Vec<&str> = stats
+        .academic
+        .courses_per_semester
+        .iter()
+        .map(|s| s.label.as_str())
+        .collect();
+    // Ordered by order_key: 2022 winter < 2023 winter < 2023 spring, with
+    // Hebrew season labels + start_year.
+    assert_eq!(labels, vec!["חורף 2022", "חורף 2023", "אביב 2023"]);
+    let values: Vec<i64> = stats
+        .academic
+        .courses_per_semester
+        .iter()
+        .map(|s| s.value)
+        .collect();
+    assert_eq!(values, vec![3, 5, 8]);
+}
+
+#[test]
+fn most_taken_courses_enriched_with_names() {
+    let f = facet_from_bson(bson::doc! {
+        "top_courses": [
+            { "_id": "01040031", "count": 50i64 },
+            { "_id": "99999999", "count": 3i64 }, // unknown -> falls back to id
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &courses_fixture());
+    assert_eq!(
+        stats.academic.most_taken_courses[0].course_name,
+        "חשבון אינפיניטסימלי 1מ'"
+    );
+    assert_eq!(stats.academic.most_taken_courses[0].count, 50);
+    // Most-taken rows carry no grade/fail/repeat data.
+    assert_eq!(stats.academic.most_taken_courses[0].average_grade, None);
+    assert_eq!(stats.academic.most_taken_courses[0].fail_rate, None);
+    assert_eq!(stats.academic.most_taken_courses[0].times_repeated, None);
+    assert_eq!(stats.academic.most_taken_courses[1].course_name, "99999999");
+}
+
+#[test]
+fn hardest_courses_ranked_by_fail_rate() {
+    let f = facet_from_bson(bson::doc! {
+        "hardest": [
+            { "_id": "01040031", "takers": 10i64, "graded": 10i64, "fails": 5i64, "avg_grade": 60.0, "total_repeats": 4i64 },
+            { "_id": "01040166", "takers": 8i64, "graded": 8i64, "fails": 1i64, "avg_grade": 80.0, "total_repeats": 1i64 },
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &courses_fixture());
+    // 50% fail rate ranks ahead of 12.5%. fail_rate is a fraction in [0, 1].
+    let top = &stats.academic.hardest_courses[0];
+    assert_eq!(top.course_id, "01040031");
+    assert_eq!(top.fail_rate, Some(0.5));
+    assert_eq!(top.average_grade, Some(60.0));
+    assert_eq!(top.count, 10); // takers
+    assert_eq!(top.times_repeated, Some(4));
+}
+
+#[test]
+fn gpa_distribution_buckets_mapped() {
+    let f = facet_from_bson(bson::doc! {
+        "gpa": [
+            { "_id": 0i32, "count": 1i64 },
+            { "_id": 3i32, "count": 4i64 },
+            { "_id": 5i32, "count": 2i64 },
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &HashMap::new());
+    assert_eq!(stats.academic.gpa_distribution[0].value, 1);
+    assert_eq!(stats.academic.gpa_distribution[3].value, 4);
+    assert_eq!(stats.academic.gpa_distribution[5].value, 2);
+    assert_eq!(stats.academic.gpa_distribution[5].label, "95-100");
+}
+
+#[test]
+fn bank_completion_rates_sorted_ascending() {
+    let f = facet_from_bson(bson::doc! {
+        "bank_completion": [
+            { "_id": "חובה", "total": 10i64, "completed": 9i64 },
+            { "_id": "רשימה א", "total": 10i64, "completed": 2i64 },
+        ],
+    });
+    let stats = DashboardStats::from_facet(f, &HashMap::new());
+    // Lowest completion (the bottleneck) first. completion_rate is a fraction in [0, 1].
+    assert_eq!(stats.academic.bank_completion[0].bank_name, "רשימה א");
+    assert_eq!(stats.academic.bank_completion[0].completion_rate, 0.2);
+    assert_eq!(stats.academic.bank_completion[1].completion_rate, 0.9);
+}
+
+#[test]
+fn pipeline_builds_single_facet_stage() {
+    let pipeline = build_pipeline(1_700_000_000_000);
+    assert_eq!(pipeline.len(), 1);
+    assert!(pipeline[0].contains_key("$facet"));
+}
+
+// --- Live-DB integration test (gated on the test-env pattern) --------------
+
+/// Runs the real aggregation against the configured test database when
+/// `SOGRIM_URI` is set. Skips cleanly otherwise so CI without a DB still passes.
+#[tokio::test]
+async fn compute_against_live_db_when_available() {
+    let _ = dotenvy::dotenv();
+    let Ok(uri) = std::env::var("SOGRIM_URI") else {
+        eprintln!("SOGRIM_URI not set; skipping live-DB stats test");
+        return;
+    };
+    let profile = std::env::var("SOGRIM_PROFILE").unwrap_or_else(|_| "debug".into());
+    let db = Db::connect(&uri, &profile)
+        .await
+        .expect("connect to test DB");
+    let courses = HashMap::new();
+    let stats = DashboardStats::compute(&db, &courses)
+        .await
+        .expect("compute stats");
+    // Sanity invariants that must hold for any non-corrupt collection.
+    assert!(stats.overview.total_users >= 0);
+    assert!(stats.overview.dau <= stats.overview.wau);
+    assert!(stats.overview.wau <= stats.overview.mau);
+    assert!(stats.overview.mau <= stats.overview.total_users);
+    // The 3 recency buckets partition all users.
+    let recency_sum =
+        stats.activity.active + stats.activity.dormant + stats.activity.inactive;
+    assert_eq!(recency_sum, stats.overview.total_users);
+    assert_eq!(stats.activity.last_active_heatmap.len(), 7);
+    assert_eq!(stats.academic.gpa_distribution.len(), GPA_BUCKETS.len());
+    // generated_at is always populated.
+    assert!(!stats.generated_at.is_empty());
+}

--- a/packages/server/src/db/services.rs
+++ b/packages/server/src/db/services.rs
@@ -8,6 +8,30 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::{Db, FilterOption, InsertOption, Resource};
 
 impl Db {
+    /// Run an aggregation pipeline against an arbitrary collection and deserialize
+    /// each result document into `R`. This is the generic escape hatch for read-only
+    /// analytics pipelines (e.g. the admin BI `$facet`) that do not map onto a single
+    /// `Resource`. The raw client + profile drive the collection handle directly.
+    pub async fn aggregate<R>(
+        &self,
+        collection: &str,
+        pipeline: Vec<bson::Document>,
+    ) -> Result<Vec<R>, AppError>
+    where
+        R: DeserializeOwned + Send + Sync,
+    {
+        let docs: Vec<bson::Document> = self
+            .client()
+            .database(self.profile())
+            .collection::<bson::Document>(collection)
+            .aggregate(pipeline)
+            .await?
+            .try_collect()
+            .await?;
+        docs.into_iter()
+            .map(|d| bson::deserialize_from_document(d).map_err(AppError::from))
+            .collect()
+    }
     pub async fn get<R>(&self, id: impl Serialize) -> Result<R, AppError>
     where
         R: Resource + Send + Sync + Unpin,

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -46,6 +46,24 @@ async fn main() -> anyhow::Result<()> {
         .context("failed to connect to MongoDB")?;
     info!(target: "server", "Initialized DB client in {}ms", now.elapsed().as_millis());
 
+    // Idempotently create the `last_seen` index on Users. The admin BI dashboard's
+    // DAU/WAU/MAU windows filter on this field. `create_index` is a no-op if an
+    // equivalent index already exists, so this is safe to run on every startup.
+    match db
+        .client()
+        .database(db.profile())
+        .collection::<bson::Document>("Users")
+        .create_index(
+            mongodb::IndexModel::builder()
+                .keys(bson::doc! { "last_seen": 1 })
+                .build(),
+        )
+        .await
+    {
+        Ok(_) => info!(target: "server", "Ensured last_seen index on Users"),
+        Err(e) => log::warn!(target: "server", "Failed to create last_seen index on Users: {e}"),
+    }
+
     // Initialize JWT decoder
     let jwt_decoder = JwtDecoder::new(config.client_id).await;
     info!(target: "server", "Initialized JWT decoder in {}ms", now.elapsed().as_millis());
@@ -91,6 +109,7 @@ async fn main() -> anyhow::Result<()> {
             "/parse-compute",
             post(api::admins::parse_courses_and_compute_degree_status),
         )
+        .route("/stats", get(api::admins::get_stats))
         .layer(Extension(Permissions::Admin));
 
     // Owner routes
@@ -126,7 +145,8 @@ async fn main() -> anyhow::Result<()> {
         .layer(cors::cors(is_debug))
         .layer(Extension(db))
         .layer(Extension(course_cache))
-        .layer(Extension(jwt_decoder));
+        .layer(Extension(jwt_decoder))
+        .layer(Extension(core::stats::StatsCache::default()));
 
     // Optionally serve static frontend files with SPA fallback
     let app = if let Some(ref static_dir) = config.static_dir {

--- a/packages/sogrim-app-v2/bun.lock
+++ b/packages/sogrim-app-v2/bun.lock
@@ -27,6 +27,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.2",
+        "recharts": "^3.9.0",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6",
         "zustand": "^5.0.11",
@@ -248,6 +249,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A=="],
@@ -299,6 +302,8 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -354,6 +359,24 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -363,6 +386,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/type-utils": "8.57.2", "@typescript-eslint/utils": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w=="],
 
@@ -446,7 +471,31 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -469,6 +518,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
 
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
@@ -495,6 +546,8 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -552,9 +605,13 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -680,6 +737,8 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -687,6 +746,14 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "recharts": ["recharts@3.9.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -716,6 +783,8 @@
 
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
@@ -739,6 +808,8 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
@@ -765,6 +836,8 @@
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 

--- a/packages/sogrim-app-v2/package.json
+++ b/packages/sogrim-app-v2/package.json
@@ -32,6 +32,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",
+    "recharts": "^3.9.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"

--- a/packages/sogrim-app-v2/src/components/dashboard/chart-panel.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/chart-panel.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { ResponsiveContainer } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+// The palette chart-color series lives in `@/lib/chart-colors` (CHART_COLORS,
+// chartColor). Import it there; keeping it out of this file lets the component
+// stay fast-refresh friendly.
+
+export interface ChartPanelProps {
+  /** Panel heading (Hebrew, RTL). */
+  title: string;
+  /** Optional caption under the title (e.g. a data-source proxy disclaimer). */
+  description?: string;
+  /** Optional trailing slot in the header (e.g. a legend or control). */
+  action?: React.ReactNode;
+  /** Height of the chart area in px. Defaults to 280. */
+  height?: number;
+  className?: string;
+  /** A single recharts chart element (e.g. <BarChart>…</BarChart>). It is
+   *  wrapped in a ResponsiveContainer so it fills the panel width. */
+  children: React.ReactElement;
+}
+
+export function ChartPanel({
+  title,
+  description,
+  action,
+  height = 280,
+  className,
+  children,
+}: ChartPanelProps) {
+  return (
+    <Card className={cn("flex flex-col", className)}>
+      <CardHeader className="flex-row items-start justify-between gap-2 space-y-0 p-4 pb-2">
+        <div className="min-w-0">
+          <CardTitle className="text-base">{title}</CardTitle>
+          {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
+      </CardHeader>
+      <CardContent className="p-4 pt-2">
+        {/* recharts lays out in LTR SVG coordinates and does NOT support CSS
+            `dir=rtl` (it mis-positions axis labels). So the chart renders LTR and
+            the RTL appearance comes from per-axis `reversed`/`orientation="right"`
+            props. Hebrew tick/label text still renders correctly via Unicode bidi. */}
+        <div style={{ height }} dir="ltr">
+          <ResponsiveContainer width="100%" height="100%">
+            {children}
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/dashboard-page.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/dashboard-page.tsx
@@ -1,0 +1,114 @@
+import { LayoutDashboard, RefreshCw, AlertTriangle } from "lucide-react";
+import { useAdminStats } from "@/hooks/use-admin-stats";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent } from "@/components/ui/card";
+import { OverviewSection } from "./sections/overview-section";
+import { ActivitySection } from "./sections/activity-section";
+import { PopulationSection } from "./sections/population-section";
+import { FunnelSection } from "./sections/funnel-section";
+import { AcademicSection } from "./sections/academic-section";
+
+/** Admin BI dashboard: a single sectioned-scroll page fed by `GET
+ *  /admins/stats`. Dark Datadog-style, RTL Hebrew, palette-driven charts. */
+export function DashboardPage() {
+  const { data, isLoading, isError, dataUpdatedAt } = useAdminStats();
+
+  return (
+    <div dir="rtl" className="mx-auto max-w-7xl space-y-8 pb-12">
+      <DashboardHeader generatedAt={data?.generated_at} fetchedAt={dataUpdatedAt} loading={isLoading} />
+
+      {isError && <ErrorState />}
+
+      {isLoading && <LoadingState />}
+
+      {data && !isError && (
+        <div className="space-y-8">
+          <OverviewSection data={data.overview} />
+          <ActivitySection data={data.activity} />
+          <PopulationSection data={data.population} />
+          <FunnelSection data={data.funnel} />
+          <AcademicSection data={data.academic} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DashboardHeader({
+  generatedAt,
+  fetchedAt,
+  loading,
+}: {
+  generatedAt?: string;
+  fetchedAt?: number;
+  loading: boolean;
+}) {
+  const updated = generatedAt ? new Date(generatedAt) : fetchedAt ? new Date(fetchedAt) : null;
+  const updatedLabel = updated
+    ? updated.toLocaleString("he-IL", { hour: "2-digit", minute: "2-digit", day: "2-digit", month: "2-digit" })
+    : null;
+
+  return (
+    <header className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-center gap-3">
+        <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-chart-1/15 text-chart-1">
+          <LayoutDashboard className="h-5 w-5" />
+        </span>
+        <div>
+          <h1 className="text-2xl font-bold leading-tight text-foreground">לוח בקרה</h1>
+          <p className="text-sm text-muted-foreground">תובנות שימוש ונתונים אקדמיים</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-xs text-muted-foreground">
+        {loading ? (
+          <>
+            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+            <span>טוען נתונים…</span>
+          </>
+        ) : (
+          <>
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success opacity-60" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-success" />
+            </span>
+            <span>{updatedLabel ? `עודכן ${updatedLabel}` : "פעיל"}</span>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}
+
+function ErrorState() {
+  return (
+    <Card className="border-destructive/40">
+      <CardContent className="flex items-center gap-3 p-6 text-sm text-muted-foreground">
+        <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />
+        <span>טעינת נתוני לוח הבקרה נכשלה. נסו לרענן את העמוד.</span>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="space-y-8" aria-busy="true">
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 8 }, (_, i) => (
+          <Skeleton key={i} className="h-24 rounded-xl" />
+        ))}
+      </div>
+      {/* Two chart rows */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+        <Skeleton className="h-72 rounded-xl" />
+        <Skeleton className="h-72 rounded-xl lg:col-span-2" />
+      </div>
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <Skeleton className="h-80 rounded-xl" />
+        <Skeleton className="h-80 rounded-xl" />
+      </div>
+    </div>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/academic-section.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/academic-section.tsx
@@ -1,0 +1,314 @@
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+  CartesianGrid,
+} from "recharts";
+import type { AcademicStats } from "@/types/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartPanel } from "@/components/dashboard/chart-panel";
+import { chartColor } from "@/lib/chart-colors";
+import { SectionHeading } from "./section-heading";
+import { ChartTooltip } from "./chart-tooltip";
+import { num, pct } from "./format";
+
+/** "<id> - <name>" when the name is known, else just the id. Keeps course rows
+ *  informative even when the course cache hasn't resolved a name. */
+function courseLabel(c: { course_id: string; course_name?: string }): string {
+  const name = c.course_name?.trim();
+  return name && name !== c.course_id ? `${c.course_id} - ${name}` : c.course_id;
+}
+
+export function AcademicSection({ data }: { data: AcademicStats }) {
+  const topCourses = data.most_taken_courses.map((c) => ({
+    label: courseLabel(c),
+    value: c.count,
+  }));
+
+  return (
+    <section>
+      <SectionHeading
+        index="05"
+        title="תובנות אקדמיות"
+        caption="מגמות קורסים, ציונים, ובנקי דרישות"
+      />
+
+      <div className="space-y-3">
+        {/* Row 1: per-semester trend (full width) */}
+        <ChartPanel
+          title="קורסים נלקחו לפי סמסטר"
+          description="ספירת קורסים על ציר הזמן האקדמי"
+          height={260}
+        >
+          <AreaChart data={data.courses_per_semester} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+            <defs>
+              <linearGradient id="semesterFill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="var(--chart-1)" stopOpacity={0.4} />
+                <stop offset="100%" stopColor="var(--chart-1)" stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid vertical={false} stroke="var(--border)" strokeOpacity={0.4} />
+            <XAxis
+              dataKey="label"
+              reversed
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              orientation="right"
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip cursor={{ stroke: "var(--border)" }} content={<ChartTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="value"
+              name="קורסים"
+              stroke="var(--chart-1)"
+              strokeWidth={2}
+              fill="url(#semesterFill)"
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ChartPanel>
+
+        {/* Row 2: top courses + GPA distribution */}
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <ChartPanel
+            title="הקורסים הנפוצים ביותר"
+            description="לפי מספר הסטודנטים שלקחו"
+            height={Math.max(280, topCourses.length * 24)}
+          >
+            <BarChart data={topCourses} layout="vertical" margin={{ left: 8, right: 16 }}>
+              <CartesianGrid horizontal={false} stroke="var(--border)" strokeOpacity={0.4} />
+              <XAxis
+                type="number"
+                reversed
+                tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                type="category"
+                dataKey="label"
+                orientation="right"
+                width={220}
+                tick={{ fontSize: 10, fill: "var(--foreground)" }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <Tooltip cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} content={<ChartTooltip />} />
+              <Bar dataKey="value" name="סטודנטים" radius={[4, 0, 0, 4]} isAnimationActive={false}>
+                {topCourses.map((entry, i) => (
+                  <Cell key={entry.label} fill={chartColor(i % 6)} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ChartPanel>
+
+          <GpaDistribution data={data} />
+        </div>
+
+        {/* Row 3: hardest courses + bank completion */}
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <HardestCourses data={data} />
+          <BankCompletion data={data} />
+        </div>
+
+        {/* Row 4: best / worst average courses */}
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <AvgCourseTable
+            title="הקורסים עם הממוצע הגבוה ביותר"
+            caption="ממוצע הציונים הגבוה ביותר (מינ׳ 5 ניגשים)"
+            rows={data.best_average_courses}
+          />
+          <AvgCourseTable
+            title="הקורסים עם הממוצע הנמוך ביותר"
+            caption="ממוצע הציונים הנמוך ביותר (מינ׳ 5 ניגשים)"
+            rows={data.worst_average_courses}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/** A ranked course table showing the average grade (used for best/worst average). */
+function AvgCourseTable({
+  title,
+  caption,
+  rows,
+}: {
+  title: string;
+  caption: string;
+  rows: AcademicStats["best_average_courses"];
+}) {
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-base">{title}</CardTitle>
+        <p className="mt-1 text-xs text-muted-foreground">{caption}</p>
+      </CardHeader>
+      <CardContent className="p-4 pt-2">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[320px] text-sm">
+            <thead>
+              <tr className="border-b border-border/60 text-xs text-muted-foreground">
+                <th className="py-1.5 pe-2 text-start font-medium">קורס</th>
+                <th className="py-1.5 px-2 text-center font-medium">ממוצע</th>
+                <th className="py-1.5 ps-2 text-center font-medium">ניגשים</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((c) => (
+                <tr key={c.course_id} className="border-b border-border/30 last:border-0">
+                  <td className="py-1.5 pe-2">
+                    <span className="block truncate font-medium text-foreground">
+                      {courseLabel(c)}
+                    </span>
+                  </td>
+                  <td dir="ltr" className="py-1.5 px-2 text-center font-semibold tabular-nums text-foreground">
+                    {c.average_grade != null ? c.average_grade.toFixed(1) : "—"}
+                  </td>
+                  <td dir="ltr" className="py-1.5 ps-2 text-center tabular-nums text-muted-foreground">
+                    {num(c.count)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Student-GPA distribution. Numeric axis runs LTR (low -> high, 55 -> 100). */
+function GpaDistribution({ data }: { data: AcademicStats }) {
+  const buckets = data.gpa_distribution;
+  return (
+    <ChartPanel
+      title="התפלגות ממוצע סטודנטים"
+      description="נקודת מידע אחת לכל סטודנט (ממוצע משוקלל)"
+      height={280}
+    >
+      <BarChart data={buckets} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+        <CartesianGrid vertical={false} stroke="var(--border)" strokeOpacity={0.4} />
+        {/* LTR numeric axis: ascending grade buckets left -> right. */}
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+          axisLine={false}
+          tickLine={false}
+          interval={0}
+        />
+        <YAxis
+          orientation="left"
+          tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <Tooltip cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} content={<ChartTooltip />} />
+        <Bar dataKey="value" name="סטודנטים" radius={[4, 4, 0, 0]} isAnimationActive={false}>
+          {buckets.map((entry, i) => (
+            <Cell key={entry.label} fill={chartColor(i)} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ChartPanel>
+  );
+}
+
+/** Hardest courses: a ranked table (fail rate / avg grade / repeats). A table
+ *  reads cleaner than a multi-metric chart for this. */
+function HardestCourses({ data }: { data: AcademicStats }) {
+  const rows = data.hardest_courses;
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-base">הקורסים הקשים ביותר</CardTitle>
+        <p className="mt-1 text-xs text-muted-foreground">לפי שיעור כישלון (מינ׳ 5 ניגשים)</p>
+      </CardHeader>
+      <CardContent className="p-4 pt-2">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[420px] text-sm">
+            <thead>
+              <tr className="border-b border-border/60 text-xs text-muted-foreground">
+                <th className="py-1.5 pe-2 text-start font-medium">קורס</th>
+                <th className="py-1.5 px-2 text-center font-medium">% כישלון</th>
+                <th className="py-1.5 px-2 text-center font-medium">ממוצע</th>
+                <th className="py-1.5 ps-2 text-center font-medium">חזרות</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((c) => (
+                <tr key={c.course_id} className="border-b border-border/30 last:border-0">
+                  <td className="py-1.5 pe-2">
+                    <span className="block truncate font-medium text-foreground">
+                      {courseLabel(c)}
+                    </span>
+                  </td>
+                  <td dir="ltr" className="py-1.5 px-2 text-center tabular-nums">
+                    <span className="font-semibold text-destructive">
+                      {pct(c.fail_rate ?? 0)}
+                    </span>
+                  </td>
+                  <td dir="ltr" className="py-1.5 px-2 text-center tabular-nums text-muted-foreground">
+                    {c.average_grade != null ? c.average_grade.toFixed(1) : "—"}
+                  </td>
+                  <td dir="ltr" className="py-1.5 ps-2 text-center tabular-nums text-muted-foreground">
+                    {num(c.times_repeated ?? 0)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Requirement-bank completion — bottleneck banks first (lowest rate). */
+function BankCompletion({ data }: { data: AcademicStats }) {
+  const banks = data.bank_completion;
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-base">השלמת בנקי דרישות</CardTitle>
+        <p className="mt-1 text-xs text-muted-foreground">צווארי בקבוק ראשונים (שיעור השלמה נמוך)</p>
+      </CardHeader>
+      <CardContent className="space-y-2.5 p-4 pt-2">
+        {banks.map((b, i) => {
+          const ratePct = Math.round(b.completion_rate * 100);
+          return (
+            <div key={b.bank_name}>
+              <div className="mb-1 flex items-center justify-between gap-2 text-sm">
+                <span className="truncate font-medium text-foreground">{b.bank_name}</span>
+                <span dir="ltr" className="flex items-center gap-2 tabular-nums">
+                  <span className="font-semibold text-foreground">{ratePct}%</span>
+                  <span className="text-xs text-muted-foreground">
+                    {num(b.completed)}/{num(b.total)}
+                  </span>
+                </span>
+              </div>
+              <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="ms-auto h-full rounded-full"
+                  style={{ width: `${Math.max(ratePct, 1)}%`, backgroundColor: chartColor(i) }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/activity-section.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/activity-section.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
+import type { ActivityStats } from "@/types/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartPanel } from "@/components/dashboard/chart-panel";
+import { chartColor } from "@/lib/chart-colors";
+import { SectionHeading } from "./section-heading";
+import { ChartTooltip } from "./chart-tooltip";
+import { num } from "./format";
+
+const DAY_LABELS = ["א׳", "ב׳", "ג׳", "ד׳", "ה׳", "ו׳", "ש׳"];
+
+/** Activity recency donut + a day×hour proxy heatmap. The heatmap is a proxy:
+ *  it bins each user's single `last_seen` timestamp, not every session. */
+export function ActivitySection({ data }: { data: ActivityStats }) {
+  const recency = [
+    { label: "פעילים (עד 7 ימים)", value: data.active, color: chartColor(2) },
+    { label: "רדומים (7–30 ימים)", value: data.dormant, color: chartColor(3) },
+    { label: "לא פעילים (30 ימים+)", value: data.inactive, color: chartColor(4) },
+  ];
+  const recencyTotal = recency.reduce((s, r) => s + r.value, 0);
+
+  // Flatten the 7×24 matrix to find the max for color intensity scaling.
+  // Guard against a missing/mis-shaped payload so the panel degrades to empty
+  // instead of crashing the whole dashboard.
+  const heatmap = Array.isArray(data.last_active_heatmap) ? data.last_active_heatmap : [];
+  let maxCell = 0;
+  for (const row of heatmap) for (const cell of row) if (cell > maxCell) maxCell = cell;
+
+  return (
+    <section>
+      <SectionHeading
+        index="02"
+        title="פעילות"
+        caption="חלוקת ותק־פעילות + מפת חום יום×שעה (פרוקסי מבוסס התחברות אחרונה, שעון ישראל)"
+      />
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+        <ChartPanel
+          title="ותק פעילות"
+          description={`${num(recencyTotal)} משתמשים, לפי התחברות אחרונה`}
+          height={260}
+        >
+          <PieChart>
+            <Pie
+              data={recency}
+              dataKey="value"
+              nameKey="label"
+              innerRadius="58%"
+              outerRadius="82%"
+              paddingAngle={2}
+              stroke="var(--card)"
+              strokeWidth={2}
+              isAnimationActive={false}
+            >
+              {recency.map((entry) => (
+                <Cell key={entry.label} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip content={<ChartTooltip />} />
+            <Legend
+              verticalAlign="bottom"
+              iconType="circle"
+              wrapperStyle={{ fontSize: 12, direction: "rtl" }}
+            />
+          </PieChart>
+        </ChartPanel>
+
+        <Card className="flex flex-col lg:col-span-2">
+          <Heatmap matrix={heatmap} maxCell={maxCell} />
+        </Card>
+      </div>
+    </section>
+  );
+}
+
+/** A 7-row (Sun..Sat) × 24-col (hour) heatmap rendered as a CSS grid. Cell
+ *  intensity scales the --chart-1 token via opacity so it tracks the palette.
+ *  Hovering a cell surfaces its value in the header (no per-cell tooltips). */
+function Heatmap({ matrix, maxCell }: { matrix: number[][]; maxCell: number }) {
+  const [hover, setHover] = useState<{ day: number; hour: number; count: number } | null>(null);
+
+  return (
+    <>
+      <CardHeader className="flex-row items-start justify-between gap-2 space-y-0 p-4 pb-2">
+        <div>
+          <CardTitle className="text-base">מפת חום: יום × שעה</CardTitle>
+          <p className="mt-1 text-xs text-muted-foreground">
+            פרוקסי — נגזר מהחותם היחיד של התחברות אחרונה לכל משתמש (שעון ישראל)
+          </p>
+        </div>
+        <div
+          dir="ltr"
+          className="shrink-0 rounded-md bg-muted px-2 py-1 text-xs tabular-nums text-muted-foreground"
+        >
+          {hover
+            ? `${DAY_LABELS[hover.day]} · ${String(hover.hour).padStart(2, "0")}:00 — ${hover.count.toLocaleString("he-IL")}`
+            : "רחפו לפרטים"}
+        </div>
+      </CardHeader>
+      <CardContent className="p-4 pt-2">
+        <div dir="ltr" className="overflow-x-auto">
+          <div className="min-w-[520px]">
+            {/* Hour ruler (LTR numeric) */}
+            <div className="mb-1 grid grid-cols-[2rem_repeat(24,1fr)] gap-px">
+              <span />
+              {Array.from({ length: 24 }, (_, h) => (
+                <span
+                  key={h}
+                  className="text-center text-[9px] tabular-nums text-muted-foreground"
+                >
+                  {h % 3 === 0 ? h : ""}
+                </span>
+              ))}
+            </div>
+            {matrix.map((row, day) => (
+              <div key={day} className="mb-px grid grid-cols-[2rem_repeat(24,1fr)] gap-px">
+                <span className="flex items-center justify-end pr-1 text-[10px] text-muted-foreground">
+                  {DAY_LABELS[day]}
+                </span>
+                {row.map((count, hour) => {
+                  const intensity = maxCell > 0 ? count / maxCell : 0;
+                  // Floor the opacity so any non-zero cell is visible.
+                  const opacity = count === 0 ? 0.4 : 0.18 + intensity * 0.82;
+                  return (
+                    <div
+                      key={hour}
+                      role="img"
+                      aria-label={`${DAY_LABELS[day]} ${hour}:00 — ${count.toLocaleString("he-IL")}`}
+                      onMouseEnter={() => setHover({ day, hour, count })}
+                      onMouseLeave={() => setHover(null)}
+                      className="aspect-square rounded-[2px] border border-border/40 transition-opacity hover:!opacity-100 hover:ring-1 hover:ring-chart-1"
+                      style={{
+                        backgroundColor: count === 0 ? "var(--muted)" : "var(--chart-1)",
+                        opacity,
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/chart-tooltip.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/chart-tooltip.tsx
@@ -1,0 +1,45 @@
+import type { TooltipContentProps } from "recharts";
+
+/** A theme-aware recharts tooltip: a small card matching the app surface,
+ *  numbers localized he-IL, laid out RTL. Pass via `content={<ChartTooltip />}`.
+ *  `unit` is appended to each value (e.g. "%"); `total` (when given) appends a
+ *  share-of-population line. */
+export function ChartTooltip({
+  active,
+  payload,
+  label,
+  unit,
+}: Partial<TooltipContentProps<number, string>> & { unit?: string }) {
+  if (!active || !payload || payload.length === 0) return null;
+
+  return (
+    <div
+      dir="rtl"
+      className="rounded-lg border border-border bg-popover px-3 py-2 text-xs shadow-md"
+    >
+      {label != null && label !== "" && (
+        <p className="mb-1 font-medium text-popover-foreground">{String(label)}</p>
+      )}
+      <div className="space-y-0.5">
+        {payload.map((entry, i) => {
+          const value = typeof entry.value === "number" ? entry.value : Number(entry.value);
+          return (
+            <div key={i} className="flex items-center gap-2">
+              <span
+                className="inline-block h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: (entry.color as string) ?? "var(--chart-1)" }}
+              />
+              {entry.name != null && (
+                <span className="text-muted-foreground">{String(entry.name)}</span>
+              )}
+              <span dir="ltr" className="font-semibold tabular-nums text-popover-foreground">
+                {Number.isFinite(value) ? value.toLocaleString("he-IL") : "—"}
+                {unit ?? ""}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/format.ts
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/format.ts
@@ -1,0 +1,19 @@
+/** Shared formatting + tooltip helpers for the dashboard sections. Keeping
+ *  these out of the component files lets the section components stay
+ *  fast-refresh friendly. */
+
+/** Localized integer (he-IL grouping). */
+export function num(value: number): string {
+  return Math.round(value).toLocaleString("he-IL");
+}
+
+/** A fraction in [0, 1] -> a rounded percent string like "42%". */
+export function pct(fraction: number): string {
+  return `${Math.round(fraction * 100)}%`;
+}
+
+/** A 0..1 fraction of `whole` rendered as a percent of the population. */
+export function shareOf(part: number, whole: number): string {
+  if (whole <= 0) return "0%";
+  return pct(part / whole);
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/funnel-section.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/funnel-section.tsx
@@ -1,0 +1,67 @@
+import type { FunnelStats } from "@/types/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { chartColor } from "@/lib/chart-colors";
+import { SectionHeading } from "./section-heading";
+import { num, pct } from "./format";
+
+/** Onboarding funnel: signed in -> picked catalog -> imported grades ->
+ *  computed status. Custom decreasing bars (RTL-anchored) with per-step
+ *  drop-off vs. the previous step. */
+export function FunnelSection({ data }: { data: FunnelStats }) {
+  const steps = [
+    { label: "נרשמו", value: data.signed_in },
+    { label: "בחרו קטלוג", value: data.picked_catalog },
+    { label: "ייבאו ציונים", value: data.imported_grades },
+    { label: "חישבו תואר", value: data.computed_status },
+  ];
+  const top = steps[0].value || 1;
+
+  return (
+    <section>
+      <SectionHeading
+        index="04"
+        title="משפך אונבורדינג"
+        caption="מסע המשתמש מהרשמה ועד חישוב תואר, עם נשירה בכל שלב"
+      />
+      <Card>
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="text-base">שלבי האונבורדינג</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2.5 p-4 pt-2">
+          {steps.map((step, i) => {
+            const widthPct = (step.value / top) * 100;
+            const prev = i === 0 ? step.value : steps[i - 1].value;
+            const dropoff = prev > 0 ? 1 - step.value / prev : 0;
+            const ofTotal = top > 0 ? step.value / top : 0;
+            return (
+              <div key={step.label}>
+                <div className="mb-1 flex items-center justify-between gap-2 text-sm">
+                  <span className="font-medium text-foreground">{step.label}</span>
+                  <span dir="ltr" className="flex items-center gap-2 tabular-nums">
+                    <span className="font-semibold text-foreground">{num(step.value)}</span>
+                    <span className="text-xs text-muted-foreground">{pct(ofTotal)}</span>
+                    {i > 0 && dropoff > 0 && (
+                      <span className="text-xs font-medium text-destructive">
+                        ▼ {pct(dropoff)}
+                      </span>
+                    )}
+                  </span>
+                </div>
+                {/* RTL track: bar grows from the right (the reading start). */}
+                <div className="h-7 w-full overflow-hidden rounded-md bg-muted">
+                  <div
+                    className="ms-auto h-full rounded-md transition-[width] duration-500"
+                    style={{
+                      width: `${Math.max(widthPct, 2)}%`,
+                      backgroundColor: chartColor(i),
+                    }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/overview-section.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/overview-section.tsx
@@ -1,0 +1,51 @@
+import { Users, Activity, Zap, GraduationCap, FileUp, CheckCircle2 } from "lucide-react";
+import type { OverviewStats } from "@/types/api";
+import { StatCard } from "@/components/dashboard/stat-card";
+import { SectionHeading } from "./section-heading";
+import { pct } from "./format";
+
+/** Overview KPI strip. Activity counts derive from `last_seen` (login-only,
+ *  hourly-throttled) — point-in-time, not engagement-per-action. */
+export function OverviewSection({ data }: { data: OverviewStats }) {
+  const total = data.total_users;
+  const onboardedPct = total > 0 ? pct(data.onboarded / total) : "0%";
+  const importedPct = total > 0 ? pct(data.imported_grades / total) : "0%";
+  const computedPct = total > 0 ? pct(data.computed_status / total) : "0%";
+
+  return (
+    <section>
+      <SectionHeading
+        index="01"
+        title="סקירה כללית"
+        caption="מדדי ליבה — פעילות נגזרת מהתחברות אחרונה (לא פעולה־לפי־פעולה)"
+      />
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <StatCard
+          label="סך הכל משתמשים"
+          value={total}
+          icon={<Users className="h-4 w-4" />}
+          className="col-span-2 sm:col-span-1"
+        />
+        <StatCard label="פעילים היום" value={data.dau} icon={<Activity className="h-4 w-4" />} />
+        <StatCard label="פעילים השבוע" value={data.wau} icon={<Activity className="h-4 w-4" />} />
+        <StatCard label="פעילים החודש" value={data.mau} icon={<Activity className="h-4 w-4" />} />
+        <StatCard
+          label="דביקות (DAU/MAU)"
+          value={pct(data.stickiness)}
+          icon={<Zap className="h-4 w-4" />}
+        />
+        <StatCard
+          label="השלימו אונבורדינג"
+          value={onboardedPct}
+          icon={<GraduationCap className="h-4 w-4" />}
+        />
+        <StatCard label="ייבאו ציונים" value={importedPct} icon={<FileUp className="h-4 w-4" />} />
+        <StatCard
+          label="חישבו תואר"
+          value={computedPct}
+          icon={<CheckCircle2 className="h-4 w-4" />}
+        />
+      </div>
+    </section>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/population-section.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/population-section.tsx
@@ -1,0 +1,171 @@
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Cell, CartesianGrid } from "recharts";
+import { FACULTY_LABELS, type Faculty, type PopulationStats } from "@/types/api";
+import { ChartPanel } from "@/components/dashboard/chart-panel";
+import { chartColor } from "@/lib/chart-colors";
+import { SectionHeading } from "./section-heading";
+import { ChartTooltip } from "./chart-tooltip";
+
+/** Map the backend faculty labels to Hebrew. The "no catalog" sentinels
+ *  (Unknown/None/empty) get the onboarding wording; real faculties go through
+ *  the shared FACULTY_LABELS map (e.g. "ComputerScience" -> "מדעי המחשב"). */
+function normalizeFacultyLabel(label: string): string {
+  if (label === "Unknown" || label === "None" || label === "") return "ללא קטלוג";
+  return FACULTY_LABELS[label as Faculty] ?? label;
+}
+
+export function PopulationSection({ data }: { data: PopulationStats }) {
+  const faculty = data.by_faculty
+    .map((b) => ({ label: normalizeFacultyLabel(b.label), value: b.value }))
+    .sort((a, b) => b.value - a.value);
+
+  const adoption = data.adoption;
+
+  // The "no catalog" / "no year" sentinels aren't real tracks/years — drop them
+  // from these breakdowns (the no-catalog population is already the "ללא קטלוג"
+  // bucket in the faculty chart above).
+  const isSentinel = (label: string) =>
+    label === "None" || label === "Unknown" || label === "";
+
+  // Top tracks by user count (catalog names can be long, so cap the list).
+  const byCatalog = data.by_catalog
+    .filter((b) => !isSentinel(b.label))
+    .sort((a, b) => b.value - a.value)
+    .slice(0, 12);
+
+  // Real catalog years, ascending.
+  const byCatalogYear = data.by_catalog_year
+    .filter((b) => !isSentinel(b.label))
+    .sort((a, b) => Number(a.label) - Number(b.label));
+
+  return (
+    <section>
+      <SectionHeading
+        index="03"
+        title="אוכלוסייה"
+        caption="פילוח לפי פקולטה ואימוץ פיצ׳רים"
+      />
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+        <ChartPanel
+          title="משתמשים לפי פקולטה"
+          description="כולל קטגוריית ׳ללא קטלוג׳ (טרם בחרו מסלול)"
+          height={Math.max(260, faculty.length * 28)}
+          className="lg:col-span-2"
+        >
+          <BarChart data={faculty} layout="vertical" margin={{ left: 8, right: 16 }}>
+            <CartesianGrid horizontal={false} stroke="var(--border)" strokeOpacity={0.4} />
+            <XAxis
+              type="number"
+              orientation="bottom"
+              reversed
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              type="category"
+              dataKey="label"
+              orientation="right"
+              width={170}
+              tick={{ fontSize: 11, fill: "var(--foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} content={<ChartTooltip />} />
+            <Bar dataKey="value" name="משתמשים" radius={[4, 0, 0, 4]} isAnimationActive={false}>
+              {faculty.map((entry, i) => (
+                <Cell
+                  key={entry.label}
+                  fill={entry.label === "ללא קטלוג" ? "var(--muted-foreground)" : chartColor(i)}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartPanel>
+
+        <ChartPanel title="אימוץ פיצ׳רים" description="מצב כהה, פלטה מותאמת, מערכת שעות" height={260}>
+          <BarChart data={adoption} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+            <CartesianGrid vertical={false} stroke="var(--border)" strokeOpacity={0.4} />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11, fill: "var(--foreground)" }}
+              axisLine={false}
+              tickLine={false}
+              interval={0}
+            />
+            <YAxis
+              orientation="right"
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} content={<ChartTooltip />} />
+            <Bar dataKey="value" name="משתמשים" radius={[4, 4, 0, 0]} isAnimationActive={false}>
+              {adoption.map((entry, i) => (
+                <Cell key={entry.label} fill={chartColor(i + 1)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartPanel>
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <ChartPanel
+          title="לפי מסלול (קטלוג)"
+          description="המסלולים הנפוצים ביותר"
+          height={Math.max(260, byCatalog.length * 26)}
+        >
+          <BarChart data={byCatalog} layout="vertical" margin={{ left: 8, right: 16 }}>
+            <CartesianGrid horizontal={false} stroke="var(--border)" strokeOpacity={0.4} />
+            <XAxis
+              type="number"
+              reversed
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              type="category"
+              dataKey="label"
+              orientation="right"
+              width={210}
+              tick={{ fontSize: 10, fill: "var(--foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} content={<ChartTooltip />} />
+            <Bar dataKey="value" name="משתמשים" radius={[4, 0, 0, 4]} isAnimationActive={false}>
+              {byCatalog.map((entry, i) => (
+                <Cell key={entry.label} fill={chartColor(i)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartPanel>
+
+        <ChartPanel title="לפי שנת קטלוג" description="התפלגות לפי שנת הקטלוג" height={260}>
+          <BarChart data={byCatalogYear} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+            <CartesianGrid vertical={false} stroke="var(--border)" strokeOpacity={0.4} />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11, fill: "var(--foreground)" }}
+              axisLine={false}
+              tickLine={false}
+              interval={0}
+            />
+            <YAxis
+              orientation="right"
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} content={<ChartTooltip />} />
+            <Bar dataKey="value" name="משתמשים" radius={[4, 4, 0, 0]} isAnimationActive={false}>
+              {byCatalogYear.map((entry, i) => (
+                <Cell key={entry.label} fill={chartColor(i + 2)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartPanel>
+      </div>
+    </section>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/section-heading.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/section-heading.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+/** A labeled section divider for the sectioned-scroll dashboard. Renders a
+ *  small eyebrow index, the Hebrew title, and an optional caption, with a
+ *  hairline rule that bleeds to the section edge (Datadog-style grouping). */
+export function SectionHeading({
+  index,
+  title,
+  caption,
+  action,
+}: {
+  /** Two-digit section number (e.g. "01"); rendered LTR, monospace. */
+  index: string;
+  title: string;
+  caption?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-4 flex items-end justify-between gap-4 border-b border-border/60 pb-2">
+      <div className="flex items-baseline gap-3">
+        <span
+          dir="ltr"
+          className="font-mono text-xs font-semibold tabular-nums text-chart-1"
+        >
+          {index}
+        </span>
+        <div>
+          <h2 className="text-lg font-bold leading-none text-foreground">{title}</h2>
+          {caption && <p className="mt-1 text-xs text-muted-foreground">{caption}</p>}
+        </div>
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/dashboard/stat-card.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/stat-card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { TrendingUp, TrendingDown } from "lucide-react";
+import { ResponsiveContainer, LineChart, Line } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export interface StatCardProps {
+  /** Hebrew label shown above the value (RTL). */
+  label: string;
+  /** The headline metric. Strings are rendered as-is; numbers are localized. */
+  value: string | number;
+  /** Optional period-over-period change. Positive renders green/up, negative
+   *  red/down. `value` is a signed number; `label` is an optional caption
+   *  (e.g. "מהשבוע שעבר"). Numeric axes / numbers render LTR. */
+  delta?: { value: number; label?: string };
+  /** Optional sparkline series (e.g. a small trend). Drawn LTR with --chart-1. */
+  sparkline?: number[];
+  /** Optional icon shown at the start of the card (e.g. a lucide icon). */
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+function formatValue(value: string | number): string {
+  return typeof value === "number" ? value.toLocaleString("he-IL") : value;
+}
+
+export function StatCard({ label, value, delta, sparkline, icon, className }: StatCardProps) {
+  const deltaUp = delta ? delta.value >= 0 : false;
+
+  return (
+    <Card className={cn("overflow-hidden", className)}>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="truncate text-sm text-muted-foreground">{label}</p>
+            <p className="mt-1 text-2xl font-bold leading-tight text-foreground" dir="ltr">
+              {formatValue(value)}
+            </p>
+          </div>
+          {icon && <span className="shrink-0 text-muted-foreground">{icon}</span>}
+        </div>
+
+        {delta && (
+          <div
+            dir="ltr"
+            className={cn(
+              "mt-2 flex items-center gap-1 text-xs font-medium",
+              deltaUp ? "text-success" : "text-destructive",
+            )}
+          >
+            {deltaUp ? <TrendingUp className="h-3.5 w-3.5" /> : <TrendingDown className="h-3.5 w-3.5" />}
+            <span>
+              {deltaUp ? "+" : ""}
+              {delta.value.toLocaleString("he-IL")}
+            </span>
+            {delta.label && <span className="text-muted-foreground">{delta.label}</span>}
+          </div>
+        )}
+
+        {sparkline && sparkline.length > 1 && (
+          <div className="mt-3 h-10" dir="ltr">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={sparkline.map((v, i) => ({ i, v }))}>
+                <Line
+                  type="monotone"
+                  dataKey="v"
+                  stroke="var(--chart-1)"
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/sogrim-app-v2/src/components/layout/mobile-nav.tsx
+++ b/packages/sogrim-app-v2/src/components/layout/mobile-nav.tsx
@@ -1,6 +1,8 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import { GraduationCap, Calendar, Settings, Mail } from "lucide-react";
+import { GraduationCap, Calendar, Settings, Mail, LayoutDashboard } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useUserState } from "@/hooks/use-user-state";
+import { UserPermissions } from "@/types/api";
 
 const navItems = [
   { to: "/planner" as const, label: "תואר", icon: GraduationCap },
@@ -9,13 +11,19 @@ const navItems = [
   { to: "/contact" as const, label: "קשר", icon: Mail },
 ];
 
+const adminNavItem = { to: "/admin" as const, label: "בקרה", icon: LayoutDashboard };
+
 export function MobileNav() {
   const location = useLocation();
+  const { data: user } = useUserState();
+  const isAdmin =
+    user?.permissions === UserPermissions.Admin || user?.permissions === UserPermissions.Owner;
+  const items = isAdmin ? [...navItems, adminNavItem] : navItems;
 
   return (
     <nav className="fixed bottom-0 inset-x-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="flex items-center justify-around py-2">
-        {navItems.map((item) => {
+        {items.map((item) => {
           const isActive = location.pathname === item.to;
           return (
             <Link

--- a/packages/sogrim-app-v2/src/components/layout/sidebar.tsx
+++ b/packages/sogrim-app-v2/src/components/layout/sidebar.tsx
@@ -1,7 +1,9 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import { GraduationCap, Calendar, Settings, Mail, ChevronRight, ChevronLeft } from "lucide-react";
+import { GraduationCap, Calendar, Settings, Mail, LayoutDashboard, ChevronRight, ChevronLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUiStore } from "@/stores/ui-store";
+import { useUserState } from "@/hooks/use-user-state";
+import { UserPermissions } from "@/types/api";
 import { Hint } from "@/components/ui/hint";
 
 const navItems = [
@@ -11,10 +13,16 @@ const navItems = [
   { to: "/contact" as const, label: "צרו קשר", icon: Mail },
 ];
 
+const adminNavItem = { to: "/admin" as const, label: "לוח בקרה", icon: LayoutDashboard };
+
 export function Sidebar() {
   const location = useLocation();
   const collapsed = useUiStore((s) => s.sidebarCollapsed);
   const toggleSidebar = useUiStore((s) => s.toggleSidebar);
+  const { data: user } = useUserState();
+  const isAdmin =
+    user?.permissions === UserPermissions.Admin || user?.permissions === UserPermissions.Owner;
+  const items = isAdmin ? [...navItems, adminNavItem] : navItems;
 
   return (
     <aside
@@ -32,7 +40,7 @@ export function Sidebar() {
       </div>
 
       <nav className="flex-1 space-y-1">
-        {navItems.map((item) => {
+        {items.map((item) => {
           const isActive = location.pathname === item.to;
           return (
             <Hint key={item.to} label={collapsed ? item.label : undefined} side="left">

--- a/packages/sogrim-app-v2/src/hooks/use-admin-stats.ts
+++ b/packages/sogrim-app-v2/src/hooks/use-admin-stats.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAdminStats } from "@/lib/api";
+import { useAuthStore } from "@/stores/auth-store";
+
+/** Fetches the admin BI dashboard stats from `GET /admins/stats`. Mirrors the
+ *  server's ~5min TTL cache, so we hold the result stale for 5 minutes. */
+export function useAdminStats() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  return useQuery({
+    queryKey: ["adminStats"],
+    queryFn: getAdminStats,
+    enabled: isAuthenticated,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/packages/sogrim-app-v2/src/index.css
+++ b/packages/sogrim-app-v2/src/index.css
@@ -58,6 +58,20 @@
   --ui-notice-accent-hover: color-mix(in oklch, var(--primary) 90%, black);
   --ui-notice-link: var(--ui-notice-accent);
   --ui-notice-link-hover: var(--ui-notice-accent-hover);
+
+  /* ─────────────────────────────────────────────────────────────────
+     Categorical chart tokens — the BI dashboard reads these via
+     var(--chart-N) only (no hardcoded hex in chart components). One
+     coherent 6-hue series per palette/theme so charts recolor with the
+     active palette and dark/light. Default series (teal palette) is a
+     cool→warm spread anchored on the teal primary.
+     ───────────────────────────────────────────────────────────────── */
+  --chart-1: oklch(0.55 0.13 215);   /* teal (primary family) */
+  --chart-2: oklch(0.58 0.15 260);   /* indigo */
+  --chart-3: oklch(0.6 0.15 160);    /* green */
+  --chart-4: oklch(0.65 0.16 70);    /* amber */
+  --chart-5: oklch(0.58 0.18 25);    /* coral */
+  --chart-6: oklch(0.55 0.17 320);   /* magenta */
 }
 
 .dark {
@@ -99,6 +113,14 @@
   --ui-notice-accent-hover: color-mix(in oklch, var(--primary) 90%, white);
   --ui-notice-link: var(--ui-notice-accent);
   --ui-notice-link-hover: var(--ui-notice-accent-hover);
+
+  /* Chart tokens (dark variant) — brighter for dark surfaces */
+  --chart-1: oklch(0.68 0.13 215);
+  --chart-2: oklch(0.7 0.15 260);
+  --chart-3: oklch(0.72 0.15 160);
+  --chart-4: oklch(0.78 0.16 70);
+  --chart-5: oklch(0.7 0.18 25);
+  --chart-6: oklch(0.7 0.17 320);
 }
 
 @theme inline {
@@ -137,6 +159,13 @@
   --color-notice-accent-hover: var(--ui-notice-accent-hover);
   --color-notice-link: var(--ui-notice-link);
   --color-notice-link-hover: var(--ui-notice-link-hover);
+  /* Categorical chart colors — usable as fill-chart-1 / text-chart-1 / etc. */
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-chart-6: var(--chart-6);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -179,6 +208,13 @@
   --ui-notice-accent-hover: #6a4da6;
   --ui-notice-link: #7c5cbf;
   --ui-notice-link-hover: #6a4da6;
+  /* Chart series — OG multi-color identity: blue / coral / green / amber / purple / teal */
+  --chart-1: oklch(0.5 0.16 264);    /* OG blue */
+  --chart-2: oklch(0.62 0.15 25);    /* coral */
+  --chart-3: oklch(0.58 0.15 150);   /* green */
+  --chart-4: oklch(0.68 0.15 70);    /* amber */
+  --chart-5: oklch(0.52 0.15 295);   /* purple */
+  --chart-6: oklch(0.6 0.12 200);    /* teal */
 }
 .dark.palette-sogrim {
   --primary: oklch(0.551 0.215 264.364);
@@ -197,6 +233,13 @@
   --ui-notice-accent-hover: #6a4da6;
   --ui-notice-link: #b69df0;
   --ui-notice-link-hover: #c9b4f5;
+  /* Chart series (dark) — brighter OG multi-color */
+  --chart-1: oklch(0.65 0.18 264);
+  --chart-2: oklch(0.72 0.16 25);
+  --chart-3: oklch(0.72 0.16 150);
+  --chart-4: oklch(0.8 0.15 70);
+  --chart-5: oklch(0.66 0.18 295);
+  --chart-6: oklch(0.72 0.12 200);
 }
 
 /* Botanical apothecary — multi-accent palette in the spirit of the OG sogrim
@@ -220,6 +263,13 @@
   --ui-notice-accent-hover: #732430;
   --ui-notice-link: #8b2e3d;
   --ui-notice-link-hover: #732430;
+  /* Chart series — earthy apothecary: amber / sage / wine / teal / moss / walnut */
+  --chart-1: oklch(0.6 0.13 70);     /* amber/honey */
+  --chart-2: oklch(0.58 0.1 135);    /* sage */
+  --chart-3: oklch(0.48 0.14 15);    /* wine */
+  --chart-4: oklch(0.55 0.08 220);   /* muted teal */
+  --chart-5: oklch(0.5 0.1 150);     /* moss */
+  --chart-6: oklch(0.5 0.08 50);     /* walnut */
 }
 .dark.palette-botanical {
   --primary: oklch(0.72 0.14 70);          /* brighter amber */
@@ -237,6 +287,13 @@
   --ui-notice-accent-hover: #d4707a;
   --ui-notice-link: #e89aa5;
   --ui-notice-link-hover: #f0b0b8;
+  /* Chart series (dark) — brighter earthy tones */
+  --chart-1: oklch(0.74 0.14 70);
+  --chart-2: oklch(0.72 0.11 135);
+  --chart-3: oklch(0.62 0.15 15);
+  --chart-4: oklch(0.68 0.09 220);
+  --chart-5: oklch(0.66 0.11 150);
+  --chart-6: oklch(0.64 0.08 50);
 }
 
 /* Midnight — synthwave / late-night cinematic. Deep ink banner with neon
@@ -263,6 +320,13 @@
   --ui-notice-accent-hover: #be185d;
   --ui-notice-link: #db2777;
   --ui-notice-link-hover: #be185d;
+  /* Chart series — synthwave neon: violet / magenta / cyan / lime / pink / blue */
+  --chart-1: oklch(0.55 0.2 295);    /* electric violet */
+  --chart-2: oklch(0.55 0.2 350);    /* hot magenta */
+  --chart-3: oklch(0.58 0.13 220);   /* cyber cyan */
+  --chart-4: oklch(0.62 0.17 130);   /* lime */
+  --chart-5: oklch(0.6 0.18 15);     /* coral pink */
+  --chart-6: oklch(0.55 0.18 260);   /* neon blue */
 }
 .dark.palette-midnight {
   /* Surfaces tinted violet — the room around the neon */
@@ -294,6 +358,13 @@
   --ui-notice-accent-hover: #f9a8d4;
   --ui-notice-link: #f9a8d4;
   --ui-notice-link-hover: #fbcfe8;
+  /* Chart series (dark) — glowing neon */
+  --chart-1: oklch(0.68 0.22 295);
+  --chart-2: oklch(0.68 0.22 350);
+  --chart-3: oklch(0.74 0.15 200);
+  --chart-4: oklch(0.82 0.18 130);
+  --chart-5: oklch(0.72 0.19 15);
+  --chart-6: oklch(0.68 0.2 260);
 }
 
 /* Subtle neon glow on midnight's primary surfaces — applies a soft halo to

--- a/packages/sogrim-app-v2/src/lib/api.ts
+++ b/packages/sogrim-app-v2/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "./api-client";
-import type { AcademicSemester, Catalog, Course, DegreeStatus, UserDetails, UserSettings, UserState } from "@/types/api";
+import type { AcademicSemester, AdminStats, Catalog, Course, DegreeStatus, UserDetails, UserSettings, UserState } from "@/types/api";
 
 export async function getCatalogs(faculty?: string): Promise<Catalog[]> {
   const params = faculty ? { faculty } : undefined;
@@ -50,6 +50,12 @@ export async function putUserSettings(settings: UserSettings): Promise<UserSetti
 
 export async function postParseAndCompute(payload: { catalogId: { $oid: string }; gradeSheetAsString: string }): Promise<DegreeStatus> {
   const { data } = await apiClient.post<DegreeStatus>("/admins/parse-compute", payload);
+  return data;
+}
+
+// Admin BI dashboard
+export async function getAdminStats(): Promise<AdminStats> {
+  const { data } = await apiClient.get<AdminStats>("/admins/stats");
   return data;
 }
 

--- a/packages/sogrim-app-v2/src/lib/chart-colors.ts
+++ b/packages/sogrim-app-v2/src/lib/chart-colors.ts
@@ -1,0 +1,17 @@
+/** The categorical chart color tokens, in series order. Components pass these
+ *  straight to recharts `fill`/`stroke` so charts recolor with the active
+ *  palette + dark/light. Never hardcode hex in chart components — read from
+ *  here (or `var(--chart-N)` directly). Defined per palette/theme in index.css. */
+export const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;
+
+/** Pick a chart color by index, wrapping around the 6-color series. */
+export function chartColor(index: number): string {
+  return CHART_COLORS[((index % CHART_COLORS.length) + CHART_COLORS.length) % CHART_COLORS.length];
+}

--- a/packages/sogrim-app-v2/src/lib/query-client.ts
+++ b/packages/sogrim-app-v2/src/lib/query-client.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+
+// Don't waste retries on expired-token responses — the axios interceptor will
+// have already attempted a silent refresh by the time we get here.
+function shouldRetry(failureCount: number, error: unknown): boolean {
+  if (isAxiosError(error) && error.response?.status === 401) return false;
+  return failureCount < 2;
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      retry: shouldRetry,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: shouldRetry,
+    },
+  },
+});

--- a/packages/sogrim-app-v2/src/main.tsx
+++ b/packages/sogrim-app-v2/src/main.tsx
@@ -1,33 +1,13 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { isAxiosError } from "axios";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ErrorBoundary } from "@/components/common/error-boundary";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { startAuthRefreshLoop } from "@/lib/google-auth";
+import { queryClient } from "@/lib/query-client";
 import { router } from "./router";
 import "./index.css";
-
-// Don't waste retries on expired-token responses — the axios interceptor will
-// have already attempted a silent refresh by the time we get here.
-function shouldRetry(failureCount: number, error: unknown): boolean {
-  if (isAxiosError(error) && error.response?.status === 401) return false;
-  return failureCount < 2;
-}
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000,
-      retry: shouldRetry,
-      refetchOnWindowFocus: false,
-    },
-    mutations: {
-      retry: shouldRetry,
-    },
-  },
-});
 
 startAuthRefreshLoop();
 

--- a/packages/sogrim-app-v2/src/router.tsx
+++ b/packages/sogrim-app-v2/src/router.tsx
@@ -5,6 +5,18 @@ import { SettingsPage } from "@/components/settings/settings-page";
 import { FaqPage } from "@/components/faq/faq-page";
 import { TimetablePage } from "@/components/timetable/timetable-page";
 import { ContactPage } from "@/components/contact/contact-page";
+import { DashboardPage } from "@/components/dashboard/dashboard-page";
+import { queryClient } from "@/lib/query-client";
+import { getUserState } from "@/lib/api";
+import { UserPermissions, type UserState } from "@/types/api";
+
+/** Admin BI dashboard is gated to Admin/Owner. The server is the real
+ *  boundary (the endpoint is Admin-gated); this guard is defense-in-depth so
+ *  students never see the route. */
+const ADMIN_PERMISSIONS: ReadonlySet<UserPermissions> = new Set([
+  UserPermissions.Admin,
+  UserPermissions.Owner,
+]);
 
 const rootRoute = createRootRoute({
   component: () => (
@@ -59,6 +71,23 @@ const contactRoute = createRoute({
   component: ContactPage,
 });
 
+const adminRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/admin",
+  beforeLoad: async () => {
+    // Reuse the same cached userState the app already loads via useUserState
+    // (queryKey ["userState"]); fetch it if it isn't primed yet.
+    const user = await queryClient.ensureQueryData<UserState>({
+      queryKey: ["userState"],
+      queryFn: getUserState,
+    });
+    if (!ADMIN_PERMISSIONS.has(user.permissions)) {
+      throw redirect({ to: "/planner" });
+    }
+  },
+  component: DashboardPage,
+});
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   plannerRoute,
@@ -66,6 +95,7 @@ const routeTree = rootRoute.addChildren([
   timetableRoute,
   faqRoute,
   contactRoute,
+  adminRoute,
 ]);
 
 export const router = createRouter({ routeTree });

--- a/packages/sogrim-app-v2/src/types/api.ts
+++ b/packages/sogrim-app-v2/src/types/api.ts
@@ -114,3 +114,115 @@ export interface ComputeDegreeStatusPayload {
   catalogId: { $oid: string };
   gradeSheetAsString: string;
 }
+
+/* ───────────────────────────────────────────────────────────────────────
+   Admin BI dashboard — mirrors the backend `DashboardStats` returned by
+   `GET /api/admins/stats`. Field names are snake_case to match the Rust
+   serde default used throughout the user/degree-status model. Every metric
+   is computed from data already persisted on `Users` (no new persisted
+   stats). Deferred/time-series metrics are intentionally absent (spec §7).
+   The backend `DashboardStats` struct MUST serialize to exactly this shape.
+   ─────────────────────────────────────────────────────────────────────── */
+
+/** A `{ label, value }` pair for categorical bar/pie series. */
+export interface CountBucket {
+  label: string;
+  value: number;
+}
+
+/** Overview KPI strip. Activity counts come from `last_seen` (login-only,
+ *  hourly-throttled) and are point-in-time, not engagement-per-action. */
+export interface OverviewStats {
+  total_users: number;
+  /** `last_seen` within 1 / 7 / 30 days. */
+  dau: number;
+  wau: number;
+  mau: number;
+  /** DAU / MAU as a fraction in [0, 1]. */
+  stickiness: number;
+  /** has `details.catalog`. */
+  onboarded: number;
+  /** non-empty `course_statuses`. */
+  imported_grades: number;
+  /** has a computed degree status. */
+  computed_status: number;
+}
+
+/** Activity recency, bucketed from the single `last_seen` per user. */
+export interface ActivityStats {
+  /** `last_seen` <= 7d. */
+  active: number;
+  /** 7d < `last_seen` <= 30d. */
+  dormant: number;
+  /** `last_seen` > 30d (or never). */
+  inactive: number;
+  /** Proxy heatmap: 7 rows (day-of-week, 0 = Sunday) × 24 cols (hour),
+   *  each cell a user count from that user's single `last_seen`. */
+  last_active_heatmap: number[][];
+}
+
+/** Population breakdowns. Faculty includes an explicit "no catalog /
+ *  onboarding" bucket for users without `details.catalog`. */
+export interface PopulationStats {
+  by_faculty: CountBucket[];
+  by_catalog: CountBucket[];
+  by_catalog_year: CountBucket[];
+  /** Feature adoption: dark mode, custom palette, timetable usage. */
+  adoption: CountBucket[];
+}
+
+/** Onboarding funnel steps in order, with absolute counts at each step. */
+export interface FunnelStats {
+  signed_in: number;
+  picked_catalog: number;
+  imported_grades: number;
+  computed_status: number;
+}
+
+/** One most-taken / hardest course row, names enriched from the course cache. */
+export interface CourseStat {
+  course_id: string;
+  course_name: string;
+  /** Number of students who took the course (most-taken). */
+  count: number;
+  /** Average numeric grade among graded takes, if any. */
+  average_grade?: number;
+  /** Fraction of takes that did not pass, in [0, 1]. */
+  fail_rate?: number;
+  /** Total `times_repeated` across students. */
+  times_repeated?: number;
+}
+
+/** Requirement-bank completion (bottleneck banks). */
+export interface BankCompletionStat {
+  bank_name: string;
+  /** Fraction of students who completed this bank, in [0, 1]. */
+  completion_rate: number;
+  completed: number;
+  total: number;
+}
+
+/** Academic insights. */
+export interface AcademicStats {
+  /** Courses taken per academic semester, ordered by `semester.order_key`. */
+  courses_per_semester: CountBucket[];
+  most_taken_courses: CourseStat[];
+  /** Per-student weighted-average GPA distribution, bucketed (e.g. by 5-pt bins). */
+  gpa_distribution: CountBucket[];
+  hardest_courses: CourseStat[];
+  /** Highest-average courses (min graded-takers floor). */
+  best_average_courses: CourseStat[];
+  /** Lowest-average courses (min graded-takers floor). */
+  worst_average_courses: CourseStat[];
+  bank_completion: BankCompletionStat[];
+}
+
+export interface AdminStats {
+  overview: OverviewStats;
+  activity: ActivityStats;
+  population: PopulationStats;
+  funnel: FunnelStats;
+  academic: AcademicStats;
+  /** ISO-8601 timestamp of when the stats were computed (for the "updated" pill). */
+  generated_at: string;
+}


### PR DESCRIPTION
Admin-only BI dashboard for Sogrim. Every metric is computed from data already on `Users` — **no new persisted stats**.

## Backend
- `core/stats`: a single MongoDB `$facet` over `Users` computes every metric server-side, cached in-memory with a **5-min TTL** (no per-request rescans). Course names resolved from the embedded `course.name`. Adds a generic `Db::aggregate` helper and a `last_seen` index at startup.
- `GET /api/admins/stats`, gated at `Permissions::Admin` (the `User` extractor returns 401 below Admin). 12 unit/integration tests.

## Frontend
- Gated `/admin` route (`beforeLoad` guard) + nav entry shown only to Admin/Owner.
- Recharts dashboard: sectioned-scroll, RTL, fully **palette-driven** (`--chart-1..6` per palette, dark/light). Sections: overview KPIs (DAU/WAU/MAU, stickiness, onboarding %), activity recency + day×hour heatmap (Israel time), population (faculty / track / catalog-year / feature adoption), onboarding funnel, and academic insights (per-semester trend, most-taken, GPA distribution, hardest / best-average / worst-average courses, requirement-bank bottlenecks).

## Security
Reviewed before merge: non-admin and unauthenticated callers are **blocked server-side** — the route lives only in the Admin-gated group, behind JWT auth, with the permission read from the DB (not client-assertable). The response is aggregate-only (no PII); the client route guard is defense-in-depth.

## Notes
- Admin/Owner is granted by editing the Mongo `Users` document (no role UI yet).
- Deferred (need new data): calendar trends, signups/growth, retention cohorts. The catalog-year breakdown is sparse today (newly-added field, mostly unpopulated) and fills in over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
