### PR TITLE
Fix degree-status repetition & in-progress handling + planner UI improvements

### DIFF
--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -160,6 +160,12 @@ impl DegreeStatus {
                         // The existing entry is graded, but the new course_status is ungraded, so we keep the existing entry.
                         removed.push(course_status.clone());
                     } else {
+                        if course_status.grade == Some(Grade::NotComplete) {
+                            // The new course_status is not complete (usually means the student didn't take the test), so we keep the existing entry.
+                            removed.push(course_status.clone());
+                            return;
+                        }
+
                         // Both attempts are graded — keep the one from the latest semester.
                         if course_status.semester_order_key() > entry.semester_order_key() {
                             removed.push(entry.clone());

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -212,3 +212,7 @@ impl DegreeStatus {
         self.postprocess(&catalog);
     }
 }
+
+#[cfg(test)]
+#[path = "repetitions_tests.rs"]
+mod repetitions_tests;

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -120,11 +120,9 @@ impl DegreeStatusHandler<'_> {
 impl DegreeStatus {
     /// Collect social courses ("פעילות חברתית") from course_statuses.
     /// Social courses are used to let the user allocate the extra credit they have.
-    fn extract_social_courses(&self) -> Vec<CourseStatus> {
+    fn extract_social_courses(&mut self) -> Vec<CourseStatus> {
         self.course_statuses
-            .iter()
-            .filter(|cs| cs.is_social())
-            .cloned()
+            .extract_if(.., |cs| cs.is_social())
             .collect()
     }
 
@@ -161,7 +159,6 @@ impl DegreeStatus {
                     } else if course_status.grade.is_none() {
                         // The existing entry is graded, but the new course_status is ungraded, so we keep the existing entry.
                         removed.push(course_status.clone());
-                        return;
                     } else {
                         // Both attempts are graded — keep the one from the latest semester.
                         if course_status.semester_order_key() > entry.semester_order_key() {
@@ -184,7 +181,6 @@ impl DegreeStatus {
         // Extract social courses and superseded retake attempts, then remove them so they don't
         // affect the compute status logic; both are restored afterward for display.
         let social_courses = self.extract_social_courses();
-        self.course_statuses.retain(|cs| !cs.is_social());
         let repetitions = self.extract_repetitions();
 
         let course_banks = catalog.get_bank_traversal_order();
@@ -200,19 +196,13 @@ impl DegreeStatus {
         }
         .compute_status();
 
-        // Restore the courses that were pulled out of the computation so the frontend can still
-        // display them (e.g. in the semesters view). The superseded retake attempts were excluded
-        // above so their credit/grade is counted only once; we also clear their `type` so they are
-        // not attributed to any bank and therefore don't show up as duplicates in the requirements
-        // panel (which lists a bank's courses by matching `type == bank name`).
         self.course_statuses.extend(social_courses);
         self.course_statuses
             .extend(repetitions.into_iter().map(|mut repetition| {
-                repetition.r#type = None;
+                repetition.is_repetition = true;
                 repetition
             }));
 
-        // process the data after degree status computation
         self.postprocess(&catalog);
     }
 }

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use crate::core::types::Requirement;
 use crate::resources::{
     catalog::Catalog,
-    course::{AcademicSemester, Course, CourseBank, CourseId, CourseState, CourseStatus},
+    course::{AcademicSemester, Course, CourseBank, CourseId, CourseState, CourseStatus, Grade},
 };
 use serde::{Deserialize, Serialize};
 

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -4,9 +4,10 @@ pub mod overflow;
 pub mod postprocessing;
 pub mod preprocessing;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::core::types::Requirement;
+use crate::resources::course;
 use crate::resources::{
     catalog::Catalog,
     course::{AcademicSemester, Course, CourseBank, CourseId, CourseState, CourseStatus},
@@ -128,12 +129,62 @@ impl DegreeStatus {
             .collect()
     }
 
+    fn extract_repetitions(&mut self) -> Vec<CourseStatus> {
+        let mut kept = HashMap::new();
+        let mut removed = Vec::new();
+
+        let unique_course_ids = self
+            .course_statuses
+            .iter()
+            .map(|course_status| course_status.course.id.clone())
+            .collect::<HashSet<CourseId>>();
+
+        unique_course_ids.iter().for_each(|unique_course_id| {
+            self.course_statuses
+                .iter()
+                .filter(|course_status| &course_status.course.id == unique_course_id)
+                .for_each(|course_status| {
+                    if course_status.course.is_sport() || course_status.is_social() {
+                        // keep all sport courses
+                        kept.insert(unique_course_id.clone(), course_status.clone());
+                        return;
+                    }
+
+                    let Some(entry) = kept.get_mut(unique_course_id) else {
+                        kept.insert(unique_course_id.clone(), course_status.clone());
+                        return;
+                    };
+
+                    let Some(_) = &entry.grade else {
+                        removed.push(entry.clone());
+                        *entry = course_status.clone();
+                        return;
+                    };
+
+                    if let Some(_) = &course_status.grade {
+                        // take the one in the last semester
+                        if course_status.semester_order_key() > entry.semester_order_key() {
+                            removed.push(entry.clone());
+                            *entry = course_status.clone();
+                        } else {
+                            removed.push(course_status.clone());
+                        }
+                    }
+                });
+        });
+
+        self.course_statuses = kept.into_values().collect();
+        removed
+    }
+
     pub fn compute(&mut self, mut catalog: Catalog, mut courses: HashMap<CourseId, Course>) {
         self.preprocess(&mut catalog, &mut courses);
 
-        // Extract social courses, then remove them so they don't affect the compute status logic
+        // Extract social courses and superseded retake attempts, then remove them so they don't
+        // affect the compute status logic; both are restored afterward for display.
         let social_courses = self.extract_social_courses();
         self.course_statuses.retain(|cs| !cs.is_social());
+        let repetitions = self.extract_repetitions();
 
         let course_banks = catalog.get_bank_traversal_order();
 
@@ -148,8 +199,11 @@ impl DegreeStatus {
         }
         .compute_status();
 
-        // Restore social courses so the frontend can display them
+        // Restore the courses that were pulled out of the computation so the frontend can still
+        // display them. The superseded attempts were excluded above so their credit/grade is
+        // counted only once.
         self.course_statuses.extend(social_courses);
+        self.course_statuses.extend(repetitions);
 
         // process the data after degree status computation
         self.postprocess(&catalog);

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -7,7 +7,6 @@ pub mod preprocessing;
 use std::collections::{HashMap, HashSet};
 
 use crate::core::types::Requirement;
-use crate::resources::course;
 use crate::resources::{
     catalog::Catalog,
     course::{AcademicSemester, Course, CourseBank, CourseId, CourseState, CourseStatus},

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -154,14 +154,16 @@ impl DegreeStatus {
                         return;
                     };
 
-                    let Some(_) = &entry.grade else {
+                    if entry.grade.is_none() {
+                        // The existing entry is ungraded, so we replace it with the new one which may be graded.
                         removed.push(entry.clone());
                         *entry = course_status.clone();
+                    } else if course_status.grade.is_none() {
+                        // The existing entry is graded, but the new course_status is ungraded, so we keep the existing entry.
+                        removed.push(course_status.clone());
                         return;
-                    };
-
-                    if let Some(_) = &course_status.grade {
-                        // take the one in the last semester
+                    } else {
+                        // Both attempts are graded — keep the one from the latest semester.
                         if course_status.semester_order_key() > entry.semester_order_key() {
                             removed.push(entry.clone());
                             *entry = course_status.clone();

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -122,22 +122,21 @@ impl DegreeStatus {
     /// Social courses are used to let the user allocate the extra credit they have.
     fn extract_social_courses(&mut self) -> Vec<CourseStatus> {
         self.course_statuses
-            .extract_if(.., |cs| cs.is_social())
+            .extract_if(.., |cs| cs.course.is_social())
             .collect()
     }
 
     fn extract_repetitions(&mut self) -> Vec<CourseStatus> {
-        // Sport and social courses may legitimately repeat — a student can take
-        // several of them, sometimes sharing the same course id across semesters —
-        // so they must bypass the dedup below. They can't go through `kept`, which is
-        // keyed by course id, because same-id entries would silently overwrite each
-        // other and drop all but one. Sport courses in particular must stay in
-        // `course_statuses` so the Sport bank can count them during compute_status.
+        // Repeatable courses (sport, social, and physical-education / arts
+        // ensembles — see Course::is_repeatable) may legitimately recur — a
+        // student can take several of them, sometimes sharing the same course id
+        // across semesters — so they must bypass the dedup below. They can't go
+        // through `kept`, which is keyed by course id, because same-id entries
+        // would silently overwrite each other and drop all but one. They also stay
+        // in `course_statuses` so their bank can count them during compute_status.
         let exempt_courses = self
             .course_statuses
-            .extract_if(.., |course_status| {
-                course_status.course.is_sport() || course_status.is_social()
-            })
+            .extract_if(.., |course_status| course_status.course.is_repeatable())
             .collect::<Vec<_>>();
 
         let mut kept = HashMap::new();

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -199,10 +199,16 @@ impl DegreeStatus {
         .compute_status();
 
         // Restore the courses that were pulled out of the computation so the frontend can still
-        // display them. The superseded attempts were excluded above so their credit/grade is
-        // counted only once.
+        // display them (e.g. in the semesters view). The superseded retake attempts were excluded
+        // above so their credit/grade is counted only once; we also clear their `type` so they are
+        // not attributed to any bank and therefore don't show up as duplicates in the requirements
+        // panel (which lists a bank's courses by matching `type == bank name`).
         self.course_statuses.extend(social_courses);
-        self.course_statuses.extend(repetitions);
+        self.course_statuses
+            .extend(repetitions.into_iter().map(|mut repetition| {
+                repetition.r#type = None;
+                repetition
+            }));
 
         // process the data after degree status computation
         self.postprocess(&catalog);

--- a/packages/server/src/core/degree_status/mod.rs
+++ b/packages/server/src/core/degree_status/mod.rs
@@ -127,6 +127,19 @@ impl DegreeStatus {
     }
 
     fn extract_repetitions(&mut self) -> Vec<CourseStatus> {
+        // Sport and social courses may legitimately repeat — a student can take
+        // several of them, sometimes sharing the same course id across semesters —
+        // so they must bypass the dedup below. They can't go through `kept`, which is
+        // keyed by course id, because same-id entries would silently overwrite each
+        // other and drop all but one. Sport courses in particular must stay in
+        // `course_statuses` so the Sport bank can count them during compute_status.
+        let exempt_courses = self
+            .course_statuses
+            .extract_if(.., |course_status| {
+                course_status.course.is_sport() || course_status.is_social()
+            })
+            .collect::<Vec<_>>();
+
         let mut kept = HashMap::new();
         let mut removed = Vec::new();
 
@@ -141,12 +154,6 @@ impl DegreeStatus {
                 .iter()
                 .filter(|course_status| &course_status.course.id == unique_course_id)
                 .for_each(|course_status| {
-                    if course_status.course.is_sport() || course_status.is_social() {
-                        // keep all sport courses
-                        kept.insert(unique_course_id.clone(), course_status.clone());
-                        return;
-                    }
-
                     let Some(entry) = kept.get_mut(unique_course_id) else {
                         kept.insert(unique_course_id.clone(), course_status.clone());
                         return;
@@ -178,6 +185,8 @@ impl DegreeStatus {
         });
 
         self.course_statuses = kept.into_values().collect();
+        // Sport/social courses were never deduped — put every one of them back.
+        self.course_statuses.extend(exempt_courses);
         removed
     }
 

--- a/packages/server/src/core/degree_status/preprocessing.rs
+++ b/packages/server/src/core/degree_status/preprocessing.rs
@@ -72,6 +72,10 @@ impl DegreeStatus {
         self.overflow_msgs.clear();
         self.total_credit = 0.0;
 
+        self.course_statuses
+            .iter_mut()
+            .for_each(|course_status| course_status.is_repetition = false);
+
         self.remove_courses_added_by_algorithm();
         self.remove_irrelevant_courses_added_by_user();
         self.clear_type_for_unmodified_and_irrelevant_courses();

--- a/packages/server/src/core/degree_status/repetitions_tests.rs
+++ b/packages/server/src/core/degree_status/repetitions_tests.rs
@@ -233,6 +233,33 @@ fn social_courses_with_same_id_are_all_kept() {
 }
 
 #[test]
+fn repeatable_prefix_courses_are_kept_even_without_a_sport_tag() {
+    // A physical-education / arts course identified only by its faculty prefix
+    // (here 0324, an ensemble) carries no Sport tag, yet Course::is_repeatable
+    // exempts it from the dedup — both same-id attempts across semesters survive.
+    let (kept, removed) = extract(vec![
+        course_status(
+            "03240236",
+            2.0,
+            Some(Grade::Numeric(100)),
+            Some(CourseState::Complete),
+            sem(2022),
+        ),
+        course_status(
+            "03240236",
+            2.0,
+            Some(Grade::Numeric(100)),
+            Some(CourseState::Complete),
+            sem(2023),
+        ),
+    ]);
+
+    assert!(removed.is_empty());
+    assert_eq!(count_id(&kept, "03240236"), 2);
+    assert_eq!(kept.len(), 2);
+}
+
+#[test]
 fn only_the_duplicated_course_is_deduped_in_a_mixed_list() {
     let (kept, removed) = extract(vec![
         graded("a", 80, 2021),

--- a/packages/server/src/core/degree_status/repetitions_tests.rs
+++ b/packages/server/src/core/degree_status/repetitions_tests.rs
@@ -64,7 +64,14 @@ fn not_complete(id: &str, year: i32) -> CourseStatus {
 }
 
 fn sport(id: &str, year: i32) -> CourseStatus {
-    let mut cs = graded(id, 90, year);
+    // Sport courses are 1-credit and identified by the Sport tag (not by id).
+    let mut cs = course_status(
+        id,
+        1.0,
+        Some(Grade::Numeric(90)),
+        Some(CourseState::Complete),
+        sem(year),
+    );
     cs.course.tags = Some(vec![Tag::Sport]);
     cs
 }
@@ -191,14 +198,15 @@ fn three_attempts_keep_latest_and_remove_the_other_two() {
 }
 
 #[test]
-fn sport_retakes_are_not_treated_as_repetitions() {
-    // Sport courses bypass the repetition logic: a same-id retake is never reported
-    // as a repetition (`removed` stays empty). Because `kept` is keyed by course id,
-    // only the last-seen attempt survives — this is by design, sport may repeat.
+fn sport_courses_with_same_id_are_all_kept() {
+    // A student may take the same sport course id more than once (e.g. in different
+    // semesters). Every attempt must be preserved: sport courses are exempt from the
+    // repetition dedup and are never reported as repetitions.
     let (kept, removed) = extract(vec![sport("s1", 2022), sport("s1", 2023)]);
 
     assert!(removed.is_empty());
-    assert_eq!(count_id(&kept, "s1"), 1);
+    assert_eq!(count_id(&kept, "s1"), 2);
+    assert_eq!(kept.len(), 2);
 }
 
 #[test]
@@ -214,12 +222,14 @@ fn multiple_distinct_sport_courses_are_all_kept() {
 }
 
 #[test]
-fn social_courses_bypass_repetition_extraction() {
-    // Social-activity courses ("פעילות חברתית") are exempt just like sport courses.
+fn social_courses_with_same_id_are_all_kept() {
+    // Social-activity courses ("פעילות חברתית") may also repeat and are exempt from
+    // the dedup just like sport courses.
     let (kept, removed) = extract(vec![social("soc", 2022), social("soc", 2023)]);
 
     assert!(removed.is_empty());
-    assert_eq!(count_id(&kept, "soc"), 1);
+    assert_eq!(count_id(&kept, "soc"), 2);
+    assert_eq!(kept.len(), 2);
 }
 
 #[test]
@@ -421,4 +431,44 @@ fn compute_takes_latest_failed_attempt_and_marks_course_incomplete() {
 
     // The failed course contributes no credit; only u1 (4.0) counts.
     assert_eq!(degree_status.total_credit, 4.0);
+}
+
+fn sport_catalog() -> Catalog {
+    Catalog {
+        id: bson::oid::ObjectId::new(),
+        name: "catalog".to_string(), // no year → English requirement is skipped
+        faculty: Faculty::Unknown,
+        total_credit: 0.0,
+        description: String::new(),
+        course_banks: vec![CourseBank {
+            name: "sport".to_string(),
+            rule: Rule::Sport,
+            credit: Some(2.0),
+        }],
+        credit_overflows: vec![],
+        course_to_bank: HashMap::new(),
+        catalog_replacements: HashMap::new(),
+        common_replacements: HashMap::new(),
+    }
+}
+
+#[test]
+fn compute_keeps_all_same_id_sport_courses_and_counts_each_one() {
+    // Regression test for the sport-duplication bug: two attempts of the same sport
+    // course id must both survive compute() — previously the id-keyed dedup map
+    // silently dropped the older one — and both must count toward the sport bank.
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![sport("0394001", 2022), sport("0394001", 2023)],
+        ..Default::default()
+    };
+
+    degree_status.compute(sport_catalog(), HashMap::new());
+
+    assert_eq!(count_id(&degree_status.course_statuses, "0394001"), 2);
+    assert!(degree_status
+        .course_statuses
+        .iter()
+        .all(|course_status| !course_status.is_repetition));
+    // Both 1.0-credit sport attempts are counted (2.0), matching the bank credit.
+    assert_eq!(degree_status.total_credit, 2.0);
 }

--- a/packages/server/src/core/degree_status/repetitions_tests.rs
+++ b/packages/server/src/core/degree_status/repetitions_tests.rs
@@ -1,0 +1,424 @@
+use std::collections::HashMap;
+
+use crate::{
+    core::types::Rule,
+    resources::{
+        catalog::{Catalog, Faculty},
+        course::*,
+    },
+};
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn sem(year: i32) -> Option<AcademicSemester> {
+    Some(AcademicSemester::new(SemesterSeason::Winter, year))
+}
+
+fn course_status(
+    id: &str,
+    credit: f32,
+    grade: Option<Grade>,
+    state: Option<CourseState>,
+    semester: Option<AcademicSemester>,
+) -> CourseStatus {
+    CourseStatus {
+        course: Course {
+            id: CourseId::new(id),
+            credit,
+            name: id.to_string(),
+            tags: None,
+        },
+        state,
+        semester,
+        grade,
+        ..Default::default()
+    }
+}
+
+fn graded(id: &str, grade: u32, year: i32) -> CourseStatus {
+    course_status(
+        id,
+        3.0,
+        Some(Grade::Numeric(grade)),
+        Some(CourseState::Complete),
+        sem(year),
+    )
+}
+
+fn ungraded(id: &str, year: i32) -> CourseStatus {
+    course_status(id, 3.0, None, Some(CourseState::InProgress), sem(year))
+}
+
+fn not_complete(id: &str, year: i32) -> CourseStatus {
+    course_status(
+        id,
+        3.0,
+        Some(Grade::NotComplete),
+        Some(CourseState::NotComplete),
+        sem(year),
+    )
+}
+
+fn sport(id: &str, year: i32) -> CourseStatus {
+    let mut cs = graded(id, 90, year);
+    cs.course.tags = Some(vec![Tag::Sport]);
+    cs
+}
+
+fn social(id: &str, year: i32) -> CourseStatus {
+    let mut cs = graded(id, 90, year);
+    cs.course.name = "פעילות חברתית".to_string();
+    cs
+}
+
+/// Runs `extract_repetitions` and returns the surviving statuses together with the
+/// removed (superseded) ones. The surviving statuses come out of a `HashMap`, so
+/// callers must assert in an order-independent way.
+fn extract(statuses: Vec<CourseStatus>) -> (Vec<CourseStatus>, Vec<CourseStatus>) {
+    let mut degree_status = DegreeStatus {
+        course_statuses: statuses,
+        ..Default::default()
+    };
+    let removed = degree_status.extract_repetitions();
+    (degree_status.course_statuses, removed)
+}
+
+fn count_id(statuses: &[CourseStatus], id: &str) -> usize {
+    statuses.iter().filter(|cs| *cs.course.id == *id).count()
+}
+
+fn find<'a>(statuses: &'a [CourseStatus], id: &str) -> &'a CourseStatus {
+    statuses
+        .iter()
+        .find(|cs| *cs.course.id == *id)
+        .unwrap_or_else(|| panic!("course {id} not found"))
+}
+
+// ---------------------------------------------------------------------------
+// extract_repetitions — unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_duplicates_returns_empty_removed_and_keeps_all() {
+    let (kept, removed) = extract(vec![
+        graded("a", 80, 2021),
+        graded("b", 70, 2022),
+        graded("c", 90, 2023),
+    ]);
+
+    assert!(removed.is_empty());
+    assert_eq!(kept.len(), 3);
+    assert_eq!(count_id(&kept, "a"), 1);
+    assert_eq!(count_id(&kept, "b"), 1);
+    assert_eq!(count_id(&kept, "c"), 1);
+}
+
+#[test]
+fn ungraded_existing_is_replaced_by_graded_attempt() {
+    // The first attempt has no grade yet; a later graded attempt supersedes it.
+    let (kept, removed) = extract(vec![ungraded("dup", 2022), graded("dup", 80, 2023)]);
+
+    assert_eq!(kept.len(), 1);
+    assert_eq!(find(&kept, "dup").grade, Some(Grade::Numeric(80)));
+    assert_eq!(removed.len(), 1);
+    assert!(removed[0].grade.is_none());
+}
+
+#[test]
+fn graded_existing_is_kept_over_ungraded_attempt() {
+    let (kept, removed) = extract(vec![graded("dup", 80, 2022), ungraded("dup", 2023)]);
+
+    assert_eq!(kept.len(), 1);
+    assert_eq!(find(&kept, "dup").grade, Some(Grade::Numeric(80)));
+    assert_eq!(removed.len(), 1);
+    assert!(removed[0].grade.is_none());
+}
+
+#[test]
+fn not_complete_retake_does_not_replace_graded_attempt() {
+    // Student retook the course but didn't finish it (לא השלים) in a later semester;
+    // the earlier real grade must be kept even though the retake is more recent.
+    let (kept, removed) = extract(vec![graded("dup", 80, 2022), not_complete("dup", 2023)]);
+
+    assert_eq!(kept.len(), 1);
+    assert_eq!(find(&kept, "dup").grade, Some(Grade::Numeric(80)));
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0].grade, Some(Grade::NotComplete));
+}
+
+#[test]
+fn latest_semester_wins_when_both_attempts_are_graded() {
+    // The later semester wins regardless of which grade is higher.
+    let (kept, removed) = extract(vec![graded("dup", 90, 2022), graded("dup", 60, 2023)]);
+
+    assert_eq!(kept.len(), 1);
+    let kept_dup = find(&kept, "dup");
+    assert_eq!(kept_dup.grade, Some(Grade::Numeric(60)));
+    assert_eq!(kept_dup.semester, sem(2023));
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0].grade, Some(Grade::Numeric(90)));
+}
+
+#[test]
+fn earlier_semester_attempt_is_removed_when_both_graded() {
+    // Same as above but the newest attempt appears first in the list.
+    let (kept, removed) = extract(vec![graded("dup", 60, 2023), graded("dup", 90, 2022)]);
+
+    assert_eq!(kept.len(), 1);
+    assert_eq!(find(&kept, "dup").grade, Some(Grade::Numeric(60)));
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0].grade, Some(Grade::Numeric(90)));
+}
+
+#[test]
+fn three_attempts_keep_latest_and_remove_the_other_two() {
+    let (kept, removed) = extract(vec![
+        graded("dup", 70, 2021),
+        graded("dup", 80, 2022),
+        graded("dup", 60, 2023),
+    ]);
+
+    assert_eq!(kept.len(), 1);
+    assert_eq!(find(&kept, "dup").grade, Some(Grade::Numeric(60))); // the 2023 attempt
+    assert_eq!(removed.len(), 2);
+    let removed_grades: Vec<_> = removed.iter().map(|cs| cs.grade).collect();
+    assert!(removed_grades.contains(&Some(Grade::Numeric(70))));
+    assert!(removed_grades.contains(&Some(Grade::Numeric(80))));
+}
+
+#[test]
+fn sport_retakes_are_not_treated_as_repetitions() {
+    // Sport courses bypass the repetition logic: a same-id retake is never reported
+    // as a repetition (`removed` stays empty). Because `kept` is keyed by course id,
+    // only the last-seen attempt survives — this is by design, sport may repeat.
+    let (kept, removed) = extract(vec![sport("s1", 2022), sport("s1", 2023)]);
+
+    assert!(removed.is_empty());
+    assert_eq!(count_id(&kept, "s1"), 1);
+}
+
+#[test]
+fn multiple_distinct_sport_courses_are_all_kept() {
+    let (kept, removed) = extract(vec![
+        sport("s1", 2022),
+        sport("s2", 2022),
+        sport("s3", 2023),
+    ]);
+
+    assert!(removed.is_empty());
+    assert_eq!(kept.len(), 3);
+}
+
+#[test]
+fn social_courses_bypass_repetition_extraction() {
+    // Social-activity courses ("פעילות חברתית") are exempt just like sport courses.
+    let (kept, removed) = extract(vec![social("soc", 2022), social("soc", 2023)]);
+
+    assert!(removed.is_empty());
+    assert_eq!(count_id(&kept, "soc"), 1);
+}
+
+#[test]
+fn only_the_duplicated_course_is_deduped_in_a_mixed_list() {
+    let (kept, removed) = extract(vec![
+        graded("a", 80, 2021),
+        graded("dup", 55, 2021),
+        graded("b", 75, 2022),
+        graded("dup", 95, 2023),
+    ]);
+
+    // `a` and `b` are untouched; only `dup` collapses to its latest attempt.
+    assert_eq!(kept.len(), 3);
+    assert_eq!(count_id(&kept, "a"), 1);
+    assert_eq!(count_id(&kept, "b"), 1);
+    assert_eq!(count_id(&kept, "dup"), 1);
+    assert_eq!(find(&kept, "dup").grade, Some(Grade::Numeric(95)));
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0].grade, Some(Grade::Numeric(55)));
+}
+
+// ---------------------------------------------------------------------------
+// Repetitions through the full compute() flow (grade sheet with duplicates)
+// ---------------------------------------------------------------------------
+
+fn hova_catalog() -> Catalog {
+    Catalog {
+        id: bson::oid::ObjectId::new(),
+        name: "catalog".to_string(), // no year in the name → English requirement is skipped
+        faculty: Faculty::Unknown,
+        total_credit: 0.0,
+        description: String::new(),
+        course_banks: vec![CourseBank {
+            name: "hova".to_string(),
+            rule: Rule::All,
+            credit: Some(100.0),
+        }],
+        credit_overflows: vec![],
+        course_to_bank: HashMap::from([
+            (CourseId::new("dup"), "hova".to_string()),
+            (CourseId::new("u1"), "hova".to_string()),
+        ]),
+        catalog_replacements: HashMap::new(),
+        common_replacements: HashMap::new(),
+    }
+}
+
+fn active_instances<'a>(degree_status: &'a DegreeStatus, id: &str) -> Vec<&'a CourseStatus> {
+    degree_status
+        .course_statuses
+        .iter()
+        .filter(|cs| *cs.course.id == *id && !cs.is_repetition)
+        .collect()
+}
+
+fn repetition_instances<'a>(degree_status: &'a DegreeStatus, id: &str) -> Vec<&'a CourseStatus> {
+    degree_status
+        .course_statuses
+        .iter()
+        .filter(|cs| *cs.course.id == *id && cs.is_repetition)
+        .collect()
+}
+
+#[test]
+fn compute_keeps_latest_attempt_and_flags_the_superseded_one_as_repetition() {
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![
+            course_status(
+                "dup",
+                3.0,
+                Some(Grade::Numeric(50)),
+                Some(CourseState::NotComplete),
+                sem(2022),
+            ),
+            course_status(
+                "dup",
+                3.0,
+                Some(Grade::Numeric(80)),
+                Some(CourseState::Complete),
+                sem(2023),
+            ),
+            course_status(
+                "u1",
+                4.0,
+                Some(Grade::Numeric(90)),
+                Some(CourseState::Complete),
+                sem(2023),
+            ),
+        ],
+        ..Default::default()
+    };
+
+    degree_status.compute(hova_catalog(), HashMap::new());
+
+    // Both attempts survive the flow, but only one is active.
+    assert_eq!(count_id(&degree_status.course_statuses, "dup"), 2);
+
+    let active = active_instances(&degree_status, "dup");
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].grade, Some(Grade::Numeric(80)));
+
+    let repetitions = repetition_instances(&degree_status, "dup");
+    assert_eq!(repetitions.len(), 1);
+    assert_eq!(repetitions[0].grade, Some(Grade::Numeric(50)));
+
+    // The duplicated course is counted once (3.0), plus u1 (4.0) — never doubled.
+    assert_eq!(degree_status.total_credit, 7.0);
+}
+
+#[test]
+fn compute_keeps_passing_grade_when_retake_was_not_completed() {
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![
+            course_status(
+                "dup",
+                3.0,
+                Some(Grade::Numeric(75)),
+                Some(CourseState::Complete),
+                sem(2022),
+            ),
+            course_status(
+                "dup",
+                3.0,
+                Some(Grade::NotComplete),
+                Some(CourseState::NotComplete),
+                sem(2023),
+            ),
+            course_status(
+                "u1",
+                4.0,
+                Some(Grade::Numeric(90)),
+                Some(CourseState::Complete),
+                sem(2023),
+            ),
+        ],
+        ..Default::default()
+    };
+
+    degree_status.compute(hova_catalog(), HashMap::new());
+
+    let active = active_instances(&degree_status, "dup");
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].grade, Some(Grade::Numeric(75)));
+    assert!(active[0].completed());
+
+    let repetitions = repetition_instances(&degree_status, "dup");
+    assert_eq!(repetitions.len(), 1);
+    assert_eq!(repetitions[0].grade, Some(Grade::NotComplete));
+
+    // Only the passing earlier attempt (3.0) and u1 (4.0) count toward the total.
+    assert_eq!(degree_status.total_credit, 7.0);
+}
+
+#[test]
+fn compute_takes_latest_failed_attempt_and_marks_course_incomplete() {
+    // The student passed the course first, then retook it and failed. The latest
+    // (failed) attempt is the authoritative one, so the course counts as NOT
+    // completed and the earlier pass becomes the repetition.
+    let mut degree_status = DegreeStatus {
+        course_statuses: vec![
+            course_status(
+                "dup",
+                3.0,
+                Some(Grade::Numeric(80)),
+                Some(CourseState::Complete),
+                sem(2022),
+            ),
+            course_status(
+                "dup",
+                3.0,
+                Some(Grade::Numeric(50)),
+                Some(CourseState::NotComplete),
+                sem(2023),
+            ),
+            course_status(
+                "u1",
+                4.0,
+                Some(Grade::Numeric(90)),
+                Some(CourseState::Complete),
+                sem(2023),
+            ),
+        ],
+        ..Default::default()
+    };
+
+    degree_status.compute(hova_catalog(), HashMap::new());
+
+    // The latest (failed) attempt is the active one, so the course is not completed.
+    let active = active_instances(&degree_status, "dup");
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].grade, Some(Grade::Numeric(50)));
+    assert!(!active[0].completed());
+    assert!(active[0].not_completed());
+
+    // The earlier passing attempt is preserved as a repetition.
+    let repetitions = repetition_instances(&degree_status, "dup");
+    assert_eq!(repetitions.len(), 1);
+    assert_eq!(repetitions[0].grade, Some(Grade::Numeric(80)));
+
+    // The failed course contributes no credit; only u1 (4.0) counts.
+    assert_eq!(degree_status.total_credit, 4.0);
+}

--- a/packages/server/src/resources/course.rs
+++ b/packages/server/src/resources/course.rs
@@ -428,6 +428,8 @@ pub struct CourseStatus {
     pub additional_msg: Option<String>,
     pub modified: bool,
     pub times_repeated: usize,
+    #[serde(default)]
+    pub is_repetition: bool,
 }
 
 impl CourseStatus {

--- a/packages/server/src/resources/course.rs
+++ b/packages/server/src/resources/course.rs
@@ -17,6 +17,12 @@ use crate::sap::CourseDetails;
 
 const NON_STANDARD_PREFIXES: [&str; 4] = ["51", "52", "61", "97"];
 
+/// Course-id prefixes (canonical 8-digit form) for faculties whose courses may
+/// legitimately be taken more than once for credit: physical education / sport
+/// (0320, 0394) and the humanities-and-arts ensembles (0324 — orchestra, choir,
+/// jazz band, etc.). See [`Course::is_repeatable`].
+const REPEATABLE_PREFIXES: [&str; 3] = ["0320", "0324", "0394"];
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SemesterSeason {
@@ -358,6 +364,25 @@ impl Course {
     pub fn is_malag(&self) -> bool {
         self.is(Tag::Malag)
     }
+
+    /// True for social-activity courses ("פעילות חברתית"), identified by name.
+    pub fn is_social(&self) -> bool {
+        self.name.contains("פעילות חברתית")
+    }
+
+    /// Best-effort check for courses a student may legitimately take more than
+    /// once, and which therefore must NOT be collapsed as repetitions: sport and
+    /// social courses, and physical-education / humanities-arts ensembles
+    /// (identified by faculty prefix). This intentionally over-includes some
+    /// non-repeatable enrichment courses under those faculties, which is harmless
+    /// in practice because students don't retake them (e.g. malags).
+    pub fn is_repeatable(&self) -> bool {
+        self.is_sport()
+            || self.is_social()
+            || REPEATABLE_PREFIXES
+                .iter()
+                .any(|&prefix| self.id.starts_with(prefix))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -488,10 +513,6 @@ impl CourseStatus {
     pub fn set_type(&mut self, r#type: impl AsRef<str>) -> &mut Self {
         self.r#type = Some(r#type.as_ref().to_owned());
         self
-    }
-
-    pub fn is_social(&self) -> bool {
-        self.course.name.contains("פעילות חברתית")
     }
 
     pub fn set_msg(&mut self, msg: impl AsRef<str>) -> &mut Self {

--- a/packages/server/src/resources/tests.rs
+++ b/packages/server/src/resources/tests.rs
@@ -492,3 +492,45 @@ fn test_enrich_prefix_multiple_prefixes() {
         .course_to_bank
         .contains_key(&CourseId::new("09990001")));
 }
+
+// --- is_repeatable tests ---
+
+fn course_with(id: &str, tags: Option<Vec<Tag>>) -> Course {
+    Course {
+        id: CourseId::new(id),
+        credit: 2.0,
+        name: id.to_string(),
+        tags,
+    }
+}
+
+#[test]
+fn test_is_repeatable() {
+    // Sport tag makes a course repeatable regardless of its id.
+    assert!(course_with("12345678", Some(vec![Tag::Sport])).is_repeatable());
+
+    // Repeatable faculty prefixes: 0320/0394 (sport/PE) and 0324 (arts ensembles).
+    assert!(course_with("03940902", None).is_repeatable()); // נבחרות ספורט
+    assert!(course_with("03940800", None).is_repeatable()); // חינוך גופני
+    assert!(course_with("03200019", None).is_repeatable()); // נבחרת ספורט
+    assert!(course_with("03240236", None).is_repeatable()); // תזמורת נשיפה
+
+    // Regular academic courses are not repeatable.
+    assert!(!course_with("02340114", None).is_repeatable()); // מבוא למדמ"ח
+    assert!(!course_with("01040031", None).is_repeatable()); // אינפי 1
+
+    // A malag under a non-arts faculty is not repeatable, but a 0324 malag is —
+    // an intentional, harmless over-inclusion (students never retake malags).
+    assert!(!course_with("02140119", Some(vec![Tag::Malag])).is_repeatable());
+    assert!(course_with("03240282", Some(vec![Tag::Malag])).is_repeatable());
+
+    // Social-activity courses are folded into is_repeatable (matched by name).
+    let social = Course {
+        id: CourseId::new("09710101"),
+        credit: 1.0,
+        name: "פעילות חברתית".to_string(),
+        tags: None,
+    };
+    assert!(social.is_social());
+    assert!(social.is_repeatable());
+}

--- a/packages/sogrim-app-v2/src/components/onboarding/catalog-step.tsx
+++ b/packages/sogrim-app-v2/src/components/onboarding/catalog-step.tsx
@@ -1,4 +1,5 @@
-import { BookOpen, Loader2, ArrowRight } from "lucide-react";
+import { BookOpen, Loader2, ArrowRight, Search } from "lucide-react";
+import { useState } from "react";
 import { useCatalogs } from "@/hooks/use-catalogs";
 import { useUpdateCatalog } from "@/hooks/use-mutations";
 import {
@@ -9,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Faculty, FACULTY_LABELS } from "@/types/api";
 import type { Catalog } from "@/types/api";
@@ -22,6 +24,7 @@ interface CatalogStepProps {
 export function CatalogStep({ faculty, onBack, onError }: CatalogStepProps) {
   const { data: catalogs, isLoading } = useCatalogs(faculty);
   const updateCatalog = useUpdateCatalog();
+  const [search, setSearch] = useState("");
 
   function handleSelect(catalogId: string) {
     updateCatalog.mutate(catalogId, {
@@ -31,9 +34,15 @@ export function CatalogStep({ faculty, onBack, onError }: CatalogStepProps) {
     });
   }
 
-  const filteredCatalogs: Catalog[] = [...(catalogs ?? [])].sort(
-    (a, b) => b.year - a.year || b.name.localeCompare(a.name),
-  );
+  const query = search.trim().toLowerCase();
+  const filteredCatalogs: Catalog[] = [...(catalogs ?? [])]
+    .filter(
+      (catalog) =>
+        !query ||
+        catalog.name.toLowerCase().includes(query) ||
+        String(catalog.year).includes(query),
+    )
+    .sort((a, b) => b.year - a.year || b.name.localeCompare(a.name));
 
   if (isLoading) {
     return (
@@ -65,6 +74,19 @@ export function CatalogStep({ faculty, onBack, onError }: CatalogStepProps) {
           {FACULTY_LABELS[faculty] ?? faculty}. הקטלוג מגדיר את דרישות התואר.
         </p>
       </div>
+
+      {(catalogs ?? []).length > 0 && (
+        <div className="relative max-w-md mx-auto">
+          <Search className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="חיפוש קטלוג לפי שם או שנה"
+            className="ps-9"
+          />
+        </div>
+      )}
 
       <div className="grid gap-3 sm:grid-cols-2">
         {filteredCatalogs.map((catalog) => (
@@ -100,7 +122,9 @@ export function CatalogStep({ faculty, onBack, onError }: CatalogStepProps) {
         <div className="text-center py-8">
           <BookOpen className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
           <p className="text-muted-foreground">
-            לא נמצאו קטלוגים זמינים עבור פקולטה זו
+            {query
+              ? "לא נמצאו קטלוגים התואמים לחיפוש"
+              : "לא נמצאו קטלוגים זמינים עבור פקולטה זו"}
           </p>
         </div>
       )}

--- a/packages/sogrim-app-v2/src/components/onboarding/catalog-step.tsx
+++ b/packages/sogrim-app-v2/src/components/onboarding/catalog-step.tsx
@@ -32,7 +32,7 @@ export function CatalogStep({ faculty, onBack, onError }: CatalogStepProps) {
   }
 
   const filteredCatalogs: Catalog[] = [...(catalogs ?? [])].sort(
-    (a, b) => a.year - b.year || a.name.localeCompare(b.name),
+    (a, b) => b.year - a.year || b.name.localeCompare(a.name),
   );
 
   if (isLoading) {

--- a/packages/sogrim-app-v2/src/components/planner/banner.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/banner.tsx
@@ -167,16 +167,12 @@ export function Banner({ degreeStatus, catalog, includeInProgress, isComputing, 
   const { course_bank_requirements, course_statuses, total_credit } = degreeStatus;
 
   const totalRequired = catalog?.total_credit ?? 0;
-  const completedCredit = course_statuses.reduce(
-    (sum, cs) => (cs.state === "הושלם" && !isSocialActivityCourse(cs) ? sum + cs.course.credit : sum),
-    0
-  );
-  const inProgressCredit = course_statuses.reduce(
-    (sum, cs) => ((cs.state === "הושלם" || cs.state === "בתהליך") && !isSocialActivityCourse(cs) ? sum + cs.course.credit : sum),
-    0
-  );
-  const effectiveCredit = Math.max(inProgressCredit, total_credit);
-  const displayedCredit = includeInProgress ? effectiveCredit : completedCredit;
+  // The backend already computes the credit that actually counts toward the degree in
+  // `total_credit`, respecting bank caps/overflow. It also honors the in-progress toggle:
+  // when it's on, the server recomputes with in-progress courses treated as complete
+  // (see students.rs). So we display that authoritative value instead of re-summing course
+  // credits on the client, which ignores the degree logic and over-counts.
+  const displayedCredit = total_credit;
   const pct = totalRequired > 0 ? Math.min(100, Math.round((displayedCredit / totalRequired) * 100)) : 0;
 
   const completedBanks = course_bank_requirements.filter(

--- a/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
@@ -75,6 +75,7 @@ function courseStatusToRow(cs: CourseStatus): RowData {
     semester: cs.semester,
     sg_name: cs.specialization_group_name,
     msg: cs.additional_msg,
+    is_repetition: cs.is_repetition,
   };
 }
 
@@ -142,6 +143,20 @@ export function CourseGrid({
         filter: true,
         headerClass: "ag-header-center",
         cellClass: "ag-cell-center",
+        cellRenderer: (params: { value: string; data?: RowData }) =>
+          params.data?.is_repetition && params.data?.state !== "בתהליך" ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span className="truncate">{params.value}</span>
+              <Badge
+                variant="muted-outline"
+                className="text-[10px] px-1.5 py-0 leading-5 shrink-0"
+              >
+                חזרה
+              </Badge>
+            </span>
+          ) : (
+            params.value
+          ),
       },
       {
         headerName: "מס׳ קורס",

--- a/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
@@ -95,6 +95,7 @@ function rowToCourseStatus(row: RowData, original: CourseStatus): CourseStatus {
     state: (row.state as CourseStatus["state"]) || original.state,
     type: row.type,
     modified: true,
+    is_repetition: row.is_repetition,
   };
 }
 
@@ -266,6 +267,10 @@ export function CourseGrid({
       // Recompute state if grade changed
       if (event.colDef.field === "grade") {
         updatedRow.state = determineState(updatedRow.grade);
+        // Changing the grade invalidates the server-computed repetition flag
+        // (which attempt is superseded depends on grades). Clear it so the row
+        // isn't shown as superseded until the next degree compute re-derives it.
+        updatedRow.is_repetition = false;
       }
 
       // Validate

--- a/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
@@ -4,6 +4,8 @@ import {
   AllCommunityModule,
   type ColDef,
   type CellValueChangedEvent,
+  type RowClassParams,
+  type RowStyle,
   themeQuartz,
 } from "ag-grid-community";
 import { Trash2 } from "lucide-react";
@@ -143,20 +145,6 @@ export function CourseGrid({
         filter: true,
         headerClass: "ag-header-center",
         cellClass: "ag-cell-center",
-        cellRenderer: (params: { value: string; data?: RowData }) =>
-          params.data?.is_repetition && params.data?.state !== "בתהליך" ? (
-            <span className="inline-flex items-center gap-1.5">
-              <span className="truncate">{params.value}</span>
-              <Badge
-                variant="muted-outline"
-                className="text-[10px] px-1.5 py-0 leading-5 shrink-0"
-              >
-                חזרה
-              </Badge>
-            </span>
-          ) : (
-            params.value
-          ),
       },
       {
         headerName: "מס׳ קורס",
@@ -317,6 +305,16 @@ export function CourseGrid({
     []
   );
 
+  // Superseded retake attempts (is_repetition) no longer count toward the degree,
+  // so dim the whole row and strike its values through.
+  const getRowStyle = useCallback(
+    (params: RowClassParams<RowData>): RowStyle | undefined =>
+      params.data?.is_repetition && params.data.state !== "בתהליך"
+        ? { opacity: 0.5, textDecoration: "line-through" }
+        : undefined,
+    []
+  );
+
   return (
     <div className="space-y-0">
       <div className="w-full overflow-hidden rounded-t-lg border [&_.ag-center-cols-viewport]:!min-h-0 [&_.ag-body-viewport]:!min-h-0">
@@ -327,6 +325,7 @@ export function CourseGrid({
           rowData={rowData}
           columnDefs={columnDefs}
           defaultColDef={defaultColDef}
+          getRowStyle={getRowStyle}
           enableRtl={true}
           singleClickEdit={true}
           stopEditingWhenCellsLoseFocus={true}

--- a/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
@@ -98,6 +98,12 @@ function rowToCourseStatus(row: RowData, original: CourseStatus): CourseStatus {
   };
 }
 
+// A superseded retake attempt (an earlier take of a course that was retaken and
+// no longer counts toward the degree). In-progress rows are excluded.
+function isSupersededRepetition(data?: RowData): boolean {
+  return !!data?.is_repetition && data.state !== "בתהליך";
+}
+
 export function CourseGrid({
   courseStatuses,
   semester,
@@ -306,12 +312,18 @@ export function CourseGrid({
   );
 
   // Superseded retake attempts (is_repetition) no longer count toward the degree,
-  // so dim the whole row and strike its values through.
+  // so dim the whole row and strike its values through. The strikethrough is done
+  // via a row class (see `.repetition-row` in index.css) because a row-level
+  // text-decoration doesn't propagate to AG Grid's flex-centered cells.
   const getRowStyle = useCallback(
     (params: RowClassParams<RowData>): RowStyle | undefined =>
-      params.data?.is_repetition && params.data.state !== "בתהליך"
-        ? { opacity: 0.5, textDecoration: "line-through" }
-        : undefined,
+      isSupersededRepetition(params.data) ? { opacity: 0.5 } : undefined,
+    []
+  );
+
+  const getRowClass = useCallback(
+    (params: RowClassParams<RowData>): string | undefined =>
+      isSupersededRepetition(params.data) ? "repetition-row" : undefined,
     []
   );
 
@@ -326,6 +338,7 @@ export function CourseGrid({
           columnDefs={columnDefs}
           defaultColDef={defaultColDef}
           getRowStyle={getRowStyle}
+          getRowClass={getRowClass}
           enableRtl={true}
           singleClickEdit={true}
           stopEditingWhenCellsLoseFocus={true}

--- a/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/course-grid.tsx
@@ -4,8 +4,7 @@ import {
   AllCommunityModule,
   type ColDef,
   type CellValueChangedEvent,
-  type RowClassParams,
-  type RowStyle,
+  type RowClassRules,
   themeQuartz,
 } from "ag-grid-community";
 import { Trash2 } from "lucide-react";
@@ -135,7 +134,17 @@ export function CourseGrid({
   );
 
   const rowData = useMemo(
-    () => semesterCourses.map(courseStatusToRow),
+    () =>
+      semesterCourses.map(courseStatusToRow).sort((a, b) => {
+        // Deterministic order: non-repetition courses first, superseded retakes
+        // last; then by course number ascending (numeric-aware).
+        const aRepetition = isSupersededRepetition(a);
+        const bRepetition = isSupersededRepetition(b);
+        if (aRepetition !== bRepetition) return aRepetition ? 1 : -1;
+        return a.courseNumber.localeCompare(b.courseNumber, undefined, {
+          numeric: true,
+        });
+      }),
     [semesterCourses]
   );
 
@@ -317,18 +326,16 @@ export function CourseGrid({
   );
 
   // Superseded retake attempts (is_repetition) no longer count toward the degree,
-  // so dim the whole row and strike its values through. The strikethrough is done
-  // via a row class (see `.repetition-row` in index.css) because a row-level
-  // text-decoration doesn't propagate to AG Grid's flex-centered cells.
-  const getRowStyle = useCallback(
-    (params: RowClassParams<RowData>): RowStyle | undefined =>
-      isSupersededRepetition(params.data) ? { opacity: 0.5 } : undefined,
-    []
-  );
-
-  const getRowClass = useCallback(
-    (params: RowClassParams<RowData>): string | undefined =>
-      isSupersededRepetition(params.data) ? "repetition-row" : undefined,
+  // so dim the whole row and strike its values through (see `.repetition-row` in
+  // index.css). We use rowClassRules rather than getRowClass/getRowStyle: the
+  // latter only apply on row creation and getRowClass never removes a stale class
+  // when the flag flips (e.g. after the user grades an in-progress retake), so the
+  // strike would linger. rowClassRules is re-evaluated on every data change and
+  // toggles the class off when the condition becomes false.
+  const rowClassRules = useMemo<RowClassRules<RowData>>(
+    () => ({
+      "repetition-row": (params) => isSupersededRepetition(params.data),
+    }),
     []
   );
 
@@ -342,8 +349,7 @@ export function CourseGrid({
           rowData={rowData}
           columnDefs={columnDefs}
           defaultColDef={defaultColDef}
-          getRowStyle={getRowStyle}
-          getRowClass={getRowClass}
+          rowClassRules={rowClassRules}
           enableRtl={true}
           singleClickEdit={true}
           stopEditingWhenCellsLoseFocus={true}

--- a/packages/sogrim-app-v2/src/components/planner/requirements/bank-requirement-card.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/requirements/bank-requirement-card.tsx
@@ -28,7 +28,7 @@ export function BankRequirementCard({
   const isSpecializationGroups = bank.bank_rule_name === "specialization groups";
 
   const bankCourses = courses.filter(
-    (cs) => cs.type === bank.course_bank_name && !isReservedCourse(cs)
+    (cs) => cs.type === bank.course_bank_name && !isReservedCourse(cs) && !cs.is_repetition
   );
 
   // Totals come from the server, which already includes in-progress courses

--- a/packages/sogrim-app-v2/src/components/planner/semester-footer.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/semester-footer.tsx
@@ -37,7 +37,7 @@ export function SemesterFooter({ rows }: SemesterFooterProps) {
 
     return {
       avg,
-      doneCredit: doneCreditNoExemption !== 0 ? doneCredit : "-",
+      doneCredit,
       totalCredit,
     };
   }, [rows]);

--- a/packages/sogrim-app-v2/src/index.css
+++ b/packages/sogrim-app-v2/src/index.css
@@ -390,3 +390,10 @@
     color: var(--card-foreground);
   }
 }
+
+/* Superseded retake attempts (is_repetition) are dimmed via getRowStyle; strike
+   their values through here. A row-level text-decoration doesn't propagate to
+   AG Grid's flex-centered cells, so target the cell value element directly. */
+.ag-row.repetition-row .ag-cell-value {
+  text-decoration: line-through;
+}

--- a/packages/sogrim-app-v2/src/index.css
+++ b/packages/sogrim-app-v2/src/index.css
@@ -391,9 +391,13 @@
   }
 }
 
-/* Superseded retake attempts (is_repetition) are dimmed via getRowStyle; strike
-   their values through here. A row-level text-decoration doesn't propagate to
-   AG Grid's flex-centered cells, so target the cell value element directly. */
+/* Superseded retake attempts (is_repetition) — the `repetition-row` class is
+   toggled by rowClassRules. Dim the whole row and strike its values through.
+   The line-through targets `.ag-cell-value` because a row-level text-decoration
+   doesn't propagate to AG Grid's flex-centered cells. */
+.ag-row.repetition-row {
+  opacity: 0.5;
+}
 .ag-row.repetition-row .ag-cell-value {
   text-decoration: line-through;
 }

--- a/packages/sogrim-app-v2/src/types/api.ts
+++ b/packages/sogrim-app-v2/src/types/api.ts
@@ -55,6 +55,7 @@ export interface CourseStatus {
   specialization_group_name?: string;
   additional_msg?: string;
   times_repeated: number;
+  is_repetition?: boolean;
 }
 
 export interface CourseBankReq {

--- a/packages/sogrim-app-v2/src/types/domain.ts
+++ b/packages/sogrim-app-v2/src/types/domain.ts
@@ -10,6 +10,7 @@ export interface RowData {
   semester: AcademicSemester | null;
   sg_name?: string;
   msg?: string;
+  is_repetition?: boolean;
 }
 
 export const COURSE_STATE_OPTIONS = ["הושלם", "לא הושלם", "לא רלוונטי", "בתהליך"] as const;


### PR DESCRIPTION
## Summary

This branch reworks how the backend handles **repeated / in-progress courses** in
the degree-status computation, moves **total-credit** calculation to the backend,
and ships several **planner UI** improvements.

## Backend (`packages/server`)

### Repetition handling
- Added an `is_repetition` flag on course statuses. `extract_repetitions` now
  deduplicates multiple attempts of the same course, keeping the authoritative
  attempt (latest graded semester; a real earlier grade wins over a later
  "לא השלים") and marking the superseded ones as repetitions instead of counting
  them toward credit.
- **Fixed a data-loss bug for sport/social courses:** they were routed through an
  id-keyed map that silently dropped all but one same-id attempt (e.g. a student
  who took נבחרות/תזמורת every semester lost the earlier ones). They are now
  exempted from dedup and stay countable by their bank.
- Added `Course::is_repeatable` (sport, social, and physical-education /
  arts-ensemble faculty prefixes `0320` / `0324` / `0394`) and use it as the
  single exemption predicate in `extract_repetitions`. `is_social` moved from
  `CourseStatus` onto `Course`.

### Other fixes
- Fixed several "in progress" course edge cases and a "not complete" edge case.
- Courses are now ordered deterministically.
- Total credit is computed on the backend and surfaced through the API/domain types.

## Frontend (`packages/sogrim-app-v2`)
- **Grade import** flow.
- **Course search bar** in the planner.
- Onboarding **catalogs ordered descending**.
- Visual treatment for repetition courses (**line-through**) and a **fade-out**
  effect for irrelevant/repeated courses.
- Fixes to the **semester credit footer** and planner **banner**.

## Tests
- New `repetitions_tests.rs` covering every branch of `extract_repetitions`
  (ungraded→graded, graded + later "לא השלים", latest-semester-wins, 3 attempts,
  sport/social same-id preserved, mixed lists) plus full-`compute()` flows
  (superseded attempt flagged, failed-retake marks course incomplete, same-id
  sport counted).
- `test_is_repeatable` for sport tag, `0320/0324/0394` prefixes, and social.
- All server tests pass; `cargo fmt --check` and `cargo clippy --all-targets -D warnings` are clean.

## Notes / known limitations
- `is_repeatable` is intentionally **best-effort** and slightly over-includes
  `0324` humanities electives (which aren't truly repeatable). This is harmless in
  practice — production data shows students effectively never retake malags.
- The malag bank sums credit **without** deduping by course id, so the handful of
  students who repeated a `0324` malag get a small, cap-bounded over-count. Not
  addressed here; can be closed later by id-deduping the malag/sport banks.