### PR TITLE
Update admin activity thresholds

### DIFF
--- a/packages/server/src/core/stats/mod.rs
+++ b/packages/server/src/core/stats/mod.rs
@@ -93,9 +93,9 @@ pub struct Overview {
 pub struct Activity {
     /// `last_seen` within the last 7 days.
     pub active: i64,
-    /// `last_seen` between 7 and 30 days ago.
+    /// `last_seen` between 7 days and 4 months ago.
     pub dormant: i64,
-    /// `last_seen` older than 30 days, or never logged in.
+    /// `last_seen` older than 4 months, or never logged in.
     pub inactive: i64,
     /// Last-active proxy heatmap: 7 rows (Sun..Sat) x 24 cols (hour 0..23) in
     /// Israel local time (Asia/Jerusalem, DST-aware).
@@ -354,6 +354,7 @@ fn build_pipeline(now_ms: i64) -> Vec<bson::Document> {
     let one_day_ago = bson::DateTime::from_millis(now_ms - day_ms);
     let seven_days_ago = bson::DateTime::from_millis(now_ms - 7 * day_ms);
     let thirty_days_ago = bson::DateTime::from_millis(now_ms - 30 * day_ms);
+    let four_months_ago = bson::DateTime::from_millis(now_ms - 120 * day_ms);
 
     // A numeric-grade detector: a grade string that parses as a double. MongoDB's
     // `$convert` with `onError` returns the fallback when the string isn't numeric.
@@ -400,9 +401,9 @@ fn build_pipeline(now_ms: i64) -> Vec<bson::Document> {
                                 { "case": { "$eq": [ { "$type": "$last_seen" }, "missing" ] }, "then": "never" },
                                 { "case": { "$eq": [ "$last_seen", bson::Bson::Null ] }, "then": "never" },
                                 { "case": { "$gte": [ "$last_seen", seven_days_ago ] }, "then": "active7d" },
-                                { "case": { "$gte": [ "$last_seen", thirty_days_ago ] }, "then": "dormant7to30d" }
+                                { "case": { "$gte": [ "$last_seen", four_months_ago ] }, "then": "dormant7d_to4m" }
                             ],
-                            "default": "inactive30d_plus"
+                            "default": "inactive4m_plus"
                         }
                     }
                 } },
@@ -644,16 +645,16 @@ impl DashboardStats {
         };
 
         // Recency buckets. The frontend collapses these into 3:
-        //   active = active7d; dormant = dormant7to30d; inactive = inactive30d_plus + never.
+        //   active = active7d; dormant = dormant7d_to4m; inactive = inactive4m_plus + never.
         let mut active7d = 0;
-        let mut dormant7to30d = 0;
-        let mut inactive30d_plus = 0;
+        let mut dormant7d_to4m = 0;
+        let mut inactive4m_plus = 0;
         let mut never = 0;
         for r in &f.recency {
             match r.bucket.as_str() {
                 "active7d" => active7d = r.count,
-                "dormant7to30d" => dormant7to30d = r.count,
-                "inactive30d_plus" => inactive30d_plus = r.count,
+                "dormant7d_to4m" => dormant7d_to4m = r.count,
+                "inactive4m_plus" => inactive4m_plus = r.count,
                 "never" => never = r.count,
                 _ => {}
             }
@@ -667,8 +668,8 @@ impl DashboardStats {
         }
         let activity = Activity {
             active: active7d,
-            dormant: dormant7to30d,
-            inactive: inactive30d_plus + never,
+            dormant: dormant7d_to4m,
+            inactive: inactive4m_plus + never,
             last_active_heatmap,
         };
 

--- a/packages/server/src/core/stats/tests.rs
+++ b/packages/server/src/core/stats/tests.rs
@@ -90,8 +90,8 @@ fn recency_collapses_to_three_buckets_and_heatmap() {
     let f = facet_from_bson(bson::doc! {
         "recency": [
             { "_id": "active7d", "count": 5i64 },
-            { "_id": "dormant7to30d", "count": 3i64 },
-            { "_id": "inactive30d_plus", "count": 2i64 },
+            { "_id": "dormant7d_to4m", "count": 3i64 },
+            { "_id": "inactive4m_plus", "count": 2i64 },
             { "_id": "never", "count": 7i64 },
         ],
         "heatmap": [
@@ -102,7 +102,7 @@ fn recency_collapses_to_three_buckets_and_heatmap() {
     let stats = DashboardStats::from_facet(f, &HashMap::new());
     assert_eq!(stats.activity.active, 5);
     assert_eq!(stats.activity.dormant, 3);
-    // inactive = inactive30d_plus + never = 2 + 7.
+    // inactive = inactive4m_plus + never = 2 + 7.
     assert_eq!(stats.activity.inactive, 9);
     assert_eq!(stats.activity.last_active_heatmap[0][9], 4);
     assert_eq!(stats.activity.last_active_heatmap[6][23], 1);

--- a/packages/sogrim-app-v2/src/components/dashboard/sections/activity-section.tsx
+++ b/packages/sogrim-app-v2/src/components/dashboard/sections/activity-section.tsx
@@ -15,8 +15,8 @@ const DAY_LABELS = ["א׳", "ב׳", "ג׳", "ד׳", "ה׳", "ו׳", "ש׳"];
 export function ActivitySection({ data }: { data: ActivityStats }) {
   const recency = [
     { label: "פעילים (עד 7 ימים)", value: data.active, color: chartColor(2) },
-    { label: "רדומים (7–30 ימים)", value: data.dormant, color: chartColor(3) },
-    { label: "לא פעילים (30 ימים+)", value: data.inactive, color: chartColor(4) },
+    { label: "רדומים (7 ימים–4 חודשים)", value: data.dormant, color: chartColor(3) },
+    { label: "לא פעילים (מעל 4 חודשים)", value: data.inactive, color: chartColor(4) },
   ];
   const recencyTotal = recency.reduce((s, r) => s + r.value, 0);
 


### PR DESCRIPTION
Classify users inactive only after four months and update the dashboard labels and stats tests accordingly.