### PR TITLE
fix(app-v2): timetable overlap layout, conflict count, and mobile UI …

### DIFF
--- a/packages/sogrim-app-v2/src/components/planner/banner.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/banner.tsx
@@ -159,9 +159,12 @@ interface BannerProps {
   includeInProgress: boolean;
   isComputing: boolean;
   onToggleInProgress: (v: boolean) => void;
+  /** Pull the banner up under the header on mobile. Only safe when nothing
+   *  (i.e. the modified notice) is rendered above it. */
+  flushTop?: boolean;
 }
 
-export function Banner({ degreeStatus, catalog, includeInProgress, isComputing, onToggleInProgress }: BannerProps) {
+export function Banner({ degreeStatus, catalog, includeInProgress, isComputing, onToggleInProgress, flushTop = false }: BannerProps) {
   const [mobileExpanded, setMobileExpanded] = useState(false);
 
   const { course_bank_requirements, course_statuses, total_credit } = degreeStatus;
@@ -233,7 +236,12 @@ export function Banner({ degreeStatus, catalog, includeInProgress, isComputing, 
 
   return (
     <div
-      className="md:-mx-6 md:px-6 md:py-5"
+      className={cn(
+        // Full-bleed on mobile so the panel meets the header and screen edges,
+        // mirroring the desktop treatment instead of floating inside main's padding.
+        "-mx-4 md:-mx-6 md:px-6 md:py-5",
+        flushTop && "-mt-4 md:mt-0",
+      )}
       style={{ background: "var(--banner-bg, var(--banner))" }}
     >
       {/* ===== MOBILE: Compact summary strip ===== */}

--- a/packages/sogrim-app-v2/src/components/planner/exemptions-tab.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/exemptions-tab.tsx
@@ -60,65 +60,92 @@ export function ExemptionsTab({
   return (
     <div className="max-w-4xl mx-auto">
       <div className="rounded-xl border bg-card shadow-sm overflow-hidden">
-        {/* Table header */}
-        <div className="grid grid-cols-12 gap-2 bg-muted px-4 py-3 text-sm font-medium text-muted-foreground border-b">
+        {/* Table header — the 6-column grid only fits from sm up */}
+        <div className="hidden sm:grid grid-cols-12 gap-2 bg-muted px-4 py-3 text-sm font-medium text-muted-foreground border-b">
           <div className="col-span-4 text-right">שם הקורס</div>
           <div className="col-span-2 text-right">מס׳ קורס</div>
           <div className="col-span-2 text-center">נק״ז</div>
-          <div className="col-span-2 text-center">ציון</div>
-          <div className="col-span-1 text-center">סטטוס</div>
+          <div className="col-span-1 text-center">ציון</div>
+          <div className="col-span-2 text-center">סטטוס</div>
           <div className="col-span-1 text-center">מחק</div>
         </div>
 
         {/* Table rows */}
-        {exemptionCourses.map((cs) => (
-          <div
-            key={courseSemesterKey(cs.course._id, cs.semester)}
-            className="grid grid-cols-12 gap-2 px-4 py-3 text-sm border-b last:border-b-0 hover:bg-muted transition-colors"
-          >
-            <div className="col-span-4 text-right font-medium text-foreground truncate">
-              {cs.course.name}
-            </div>
-            <div
-              className="col-span-2 text-right text-muted-foreground"
-              dir="ltr"
+        {exemptionCourses.map((cs) => {
+          const statusBadge = (
+            <Badge
+              variant={
+                cs.state === "הושלם"
+                  ? "success-muted"
+                  : cs.state === "לא הושלם"
+                    ? "destructive-outline"
+                    : cs.state === "בתהליך"
+                      ? "info-outline"
+                      : "muted-outline"
+              }
+              className="text-[10px] whitespace-nowrap"
             >
-              {cs.course._id}
-            </div>
-            <div className="col-span-2 text-center text-foreground">
-              {cs.course.credit}
-            </div>
-            <div className="col-span-2 text-center text-foreground">
-              {cs.grade ?? "-"}
-            </div>
-            <div className="col-span-1 text-center">
-              <Badge
-                variant={
-                  cs.state === "הושלם"
-                    ? "success-muted"
-                    : cs.state === "לא הושלם"
-                      ? "destructive-outline"
-                      : cs.state === "בתהליך"
-                        ? "info-outline"
-                        : "muted-outline"
-                }
-                className="text-[10px]"
+              {cs.state}
+            </Badge>
+          );
+
+          const deleteButton = (
+            <Hint label="מחק קורס">
+              <button
+                onClick={() => onDeleteCourse(cs.course._id, null)}
+                className="flex items-center justify-center p-1 text-muted-foreground hover:text-destructive transition-colors"
+                aria-label={`מחק את ${cs.course.name}`}
               >
-                {cs.state}
-              </Badge>
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </Hint>
+          );
+
+          return (
+            <div
+              key={courseSemesterKey(cs.course._id, cs.semester)}
+              className="px-4 py-3 text-sm border-b last:border-b-0 hover:bg-muted transition-colors"
+            >
+              {/* Mobile: two stacked lines — six columns can't fit on a phone */}
+              <div className="sm:hidden">
+                <div className="flex items-center gap-2">
+                  <span className="flex-1 min-w-0 font-medium text-foreground truncate">
+                    {cs.course.name}
+                  </span>
+                  {statusBadge}
+                  <span className="shrink-0">{deleteButton}</span>
+                </div>
+                <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <span dir="ltr">{cs.course._id}</span>
+                  <span aria-hidden>·</span>
+                  <span>{cs.course.credit} נק״ז</span>
+                  <span aria-hidden>·</span>
+                  <span className="truncate">{cs.grade ?? "-"}</span>
+                </div>
+              </div>
+
+              {/* Desktop: table row matching the header above */}
+              <div className="hidden sm:grid grid-cols-12 gap-2">
+                <div className="col-span-4 text-right font-medium text-foreground truncate">
+                  {cs.course.name}
+                </div>
+                <div className="col-span-2 text-right text-muted-foreground" dir="ltr">
+                  {cs.course._id}
+                </div>
+                <div className="col-span-2 text-center text-foreground">
+                  {cs.course.credit}
+                </div>
+                <div className="col-span-1 text-center text-foreground">
+                  {cs.grade ?? "-"}
+                </div>
+                <div className="col-span-2 text-center">{statusBadge}</div>
+                <div className="col-span-1 flex justify-center items-center">
+                  {deleteButton}
+                </div>
+              </div>
             </div>
-            <div className="col-span-1 flex justify-center items-center">
-              <Hint label="מחק קורס">
-                <button
-                  onClick={() => onDeleteCourse(cs.course._id, null)}
-                  className="flex items-center justify-center text-muted-foreground hover:text-destructive transition-colors"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </Hint>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {exemptionCourses.length > 0 && (

--- a/packages/sogrim-app-v2/src/components/planner/modified-toast.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/modified-toast.tsx
@@ -1,6 +1,7 @@
 import { Loader2, Info } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { useComputeDegreeStatus } from "@/hooks/use-mutations";
 
 export function ModifiedToast({ visible = true }: { visible?: boolean }) {
@@ -9,8 +10,15 @@ export function ModifiedToast({ visible = true }: { visible?: boolean }) {
 
   return (
     <div
-      className="flex flex-wrap items-center justify-center gap-2 px-3 py-2.5 text-sm rounded-lg mb-2 md:rounded-none md:-mx-6 md:px-6 md:mb-0 md:-mt-6 md:-mb-3 relative z-10 bg-notice-bg text-notice-fg"
-      style={{ visibility: visible ? "visible" : "hidden" }}
+      className={cn(
+        "flex-wrap items-center justify-center gap-2 px-3 py-2.5 text-sm rounded-lg mb-2 md:rounded-none md:-mx-6 md:px-6 md:mb-0 md:-mt-6 md:-mb-3 relative z-10 bg-notice-bg text-notice-fg",
+        // When idle, desktop keeps reserving the strip's space (the negative
+        // margins absorb it) but mobile drops it entirely — reserving it there
+        // leaves a big blank gap between the header and the banner.
+        // `invisible` also keeps the button out of the tab order.
+        visible ? "flex" : "hidden md:flex invisible",
+      )}
+      aria-hidden={!visible}
     >
       <span className="text-center font-medium text-xs md:text-sm">
         {"סטטוס התואר שלך אינו מעודכן - עלייך להריץ שוב את חישוב סגירת התואר."}

--- a/packages/sogrim-app-v2/src/components/planner/planner-page.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/planner-page.tsx
@@ -466,7 +466,7 @@ export function PlannerPage() {
   // --- Ready state: full planner ---
   return (
     <div className="space-y-0">
-      {/* Modified Toast - always reserves space, content shown when modified */}
+      {/* Modified Toast - reserves space on desktop, hidden entirely on mobile when idle */}
       <ModifiedToast visible={isModified} />
 
       {/* Top Banner */}
@@ -475,6 +475,7 @@ export function PlannerPage() {
         catalog={details!.catalog}
         includeInProgress={includeInProgress}
         isComputing={computeInProgressMutation.isPending}
+        flushTop={!isModified}
         onToggleInProgress={(val) => {
           if (!details) return;
           computeInProgressMutation.mutate({

--- a/packages/sogrim-app-v2/src/components/planner/semester-timeline.tsx
+++ b/packages/sogrim-app-v2/src/components/planner/semester-timeline.tsx
@@ -309,7 +309,7 @@ function OrdinalChip({
             "absolute top-0.5 end-0.5 flex items-center justify-center",
             "h-4 w-4 rounded-sm cursor-pointer",
             "text-muted-foreground hover:text-destructive hover:bg-destructive/10",
-            "opacity-0 group-hover:opacity-100 transition-opacity",
+            "opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity",
           )}
         >
           <X className="h-3 w-3" />
@@ -466,7 +466,7 @@ function EmptySlotView({
         <button
           onClick={onRemoveAnnotation}
           className={cn(
-            "absolute top-0.5 end-0.5 opacity-0 group-hover:opacity-100",
+            "absolute top-0.5 end-0.5 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100",
             "transition-opacity flex items-center justify-center",
             "h-4 w-4 rounded bg-amber-500/20 hover:bg-amber-500/40",
             "text-amber-700 dark:text-amber-400",
@@ -536,7 +536,7 @@ function EmptySlotView({
             </span>
           </>
         ) : (
-          <Plus className="h-3.5 w-3.5 text-muted-foreground/50 opacity-0 group-hover:opacity-80 transition-opacity" />
+          <Plus className="h-3.5 w-3.5 text-muted-foreground/50 opacity-0 group-hover:opacity-80 pointer-coarse:opacity-80 transition-opacity" />
         )}
       </button>
       {menuOpen && menuPos && typeof document !== "undefined" && createPortal(

--- a/packages/sogrim-app-v2/src/components/timetable/conflict-badge.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/conflict-badge.tsx
@@ -1,5 +1,5 @@
 import type { TimetableEvent } from "@/types/timetable";
-import { findConflicts } from "@/lib/timetable-conflicts";
+import { chosenEvents, findConflicts } from "@/lib/timetable-conflicts";
 import { useMemo } from "react";
 import { AlertTriangle } from "lucide-react";
 
@@ -9,7 +9,7 @@ interface ConflictBadgeProps {
 
 export function ConflictBadge({ events }: ConflictBadgeProps) {
   const conflictCount = useMemo(
-    () => findConflicts(events).length,
+    () => findConflicts(chosenEvents(events)).length,
     [events],
   );
 

--- a/packages/sogrim-app-v2/src/components/timetable/day-view.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/day-view.tsx
@@ -9,7 +9,7 @@ import {
   computeVisibleRange,
   totalSlots,
   timeToRow,
-  timeSpanRows,
+  layoutEvents,
 } from "@/lib/timetable-utils";
 import { useTimetableStore } from "@/stores/timetable-store";
 import { CourseBlock } from "./course-block";
@@ -52,6 +52,12 @@ export function DayView({ events }: DayViewProps) {
   const dayEvents = useMemo(
     () => events.filter((e) => e.day === selectedDay),
     [events, selectedDay],
+  );
+
+  // Same column-packing as the week grid, so overlapping options stay visible.
+  const positionedEvents = useMemo(
+    () => layoutEvents(dayEvents, startHour, slotCount),
+    [dayEvents, startHour, slotCount],
   );
 
   const getRowFromY = (clientY: number): number => {
@@ -188,30 +194,25 @@ export function DayView({ events }: DayViewProps) {
               />
             )}
 
-            {/* Course blocks — absolutely positioned */}
-            {dayEvents.map((event) => {
-              const row = timeToRow(event.startTime, startHour);
-              const span = timeSpanRows(event.startTime, event.endTime);
-              const topPct = (row / slotCount) * 100;
-              const heightPct = (span / slotCount) * 100;
-
-              return (
-                <div
-                  key={`${event.courseId}-${event.groupId}-${event.startTime}`}
-                  className="absolute inset-x-1 z-[2]"
-                  style={{
-                    top: `${topPct}%`,
-                    height: `${heightPct}%`,
-                  }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                >
-                  <CourseBlock
-                    event={event}
-                    onCustomEventClick={handleCustomEventClick}
-                  />
-                </div>
-              );
-            })}
+            {/* Course blocks — absolutely positioned, with column layout for overlaps */}
+            {positionedEvents.map(({ event, topPct, heightPct, leftPct, widthPct }) => (
+              <div
+                key={`${event.courseId}-${event.groupId}-${event.startTime}-${event.isPreview}`}
+                className="absolute z-[2] px-0.5"
+                style={{
+                  top: `${topPct}%`,
+                  height: `${heightPct}%`,
+                  right: `${leftPct}%`,
+                  width: `${widthPct}%`,
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+              >
+                <CourseBlock
+                  event={event}
+                  onCustomEventClick={handleCustomEventClick}
+                />
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/packages/sogrim-app-v2/src/components/timetable/draft-tabs.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/draft-tabs.tsx
@@ -74,7 +74,7 @@ export function DraftTabs() {
               </button>
               <button
                 onClick={() => handleStartRename(draft.id, draft.name)}
-                className="opacity-0 group-hover:opacity-100 transition-opacity"
+                className="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity"
               >
                 <Pencil className="h-2.5 w-2.5 text-muted-foreground" />
               </button>
@@ -83,7 +83,7 @@ export function DraftTabs() {
                   e.stopPropagation();
                   deleteDraft(draft.id);
                 }}
-                className="opacity-0 group-hover:opacity-100 transition-opacity"
+                className="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity"
               >
                 <X className="h-3 w-3 text-muted-foreground hover:text-destructive" />
               </button>

--- a/packages/sogrim-app-v2/src/components/timetable/group-selector.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/group-selector.tsx
@@ -2,7 +2,6 @@ import type { CourseSchedule, LessonType } from "@/types/timetable";
 import { LESSON_TYPE_NAMES, DAY_LABELS } from "@/lib/timetable-utils";
 import { useTimetableStore } from "@/stores/timetable-store";
 import { cn } from "@/lib/utils";
-import { Eye } from "lucide-react";
 import { Hint } from "@/components/ui/hint";
 
 interface GroupSelectorProps {
@@ -12,9 +11,6 @@ interface GroupSelectorProps {
 
 export function GroupSelector({ course, selectedGroups }: GroupSelectorProps) {
   const setGroup = useTimetableStore((s) => s.setGroup);
-  const previewingCourse = useTimetableStore((s) => s.previewingCourse);
-  const previewingType = useTimetableStore((s) => s.previewingType);
-  const setPreview = useTimetableStore((s) => s.setPreview);
 
   // Group the course's groups by type
   const groupsByType = new Map<LessonType, { id: string; summary: string }[]>();
@@ -34,14 +30,10 @@ export function GroupSelector({ course, selectedGroups }: GroupSelectorProps) {
     });
   }
 
-  const isPreviewing = previewingCourse === course.id;
-
   return (
     <div className="flex flex-col gap-1.5">
       {Array.from(groupsByType.entries()).map(([type, groups]) => {
-        if (groups.length <= 1) return null;
         const selectedId = selectedGroups[type];
-        const isTypePreview = isPreviewing && previewingType === type;
 
         return (
           <div key={type} className="flex items-center gap-1.5 flex-wrap">
@@ -52,14 +44,18 @@ export function GroupSelector({ course, selectedGroups }: GroupSelectorProps) {
               {groups.map((g) => (
                 <Hint key={g.id} label={g.summary}>
                   <button
-                    onClick={() => setGroup(course.id, type, g.id)}
+                    onClick={() =>
+                      setGroup(
+                        course.id,
+                        type,
+                        g.id === selectedId ? "" : g.id,
+                      )
+                    }
                     className={cn(
                       "px-1.5 py-0.5 rounded text-[0.65rem] font-medium transition-all",
                       g.id === selectedId
                         ? "bg-primary text-primary-foreground"
-                        : isTypePreview
-                          ? "bg-primary/20 text-primary ring-1 ring-primary/30"
-                          : "bg-secondary text-secondary-foreground hover:bg-accent",
+                        : "bg-secondary text-secondary-foreground hover:bg-accent",
                     )}
                   >
                     {g.id.split("-")[0]}
@@ -67,26 +63,6 @@ export function GroupSelector({ course, selectedGroups }: GroupSelectorProps) {
                 </Hint>
               ))}
             </div>
-            {/* Preview all button */}
-            <Hint label="הצג את כל האפשרויות על המערכת">
-              <button
-                onClick={() => {
-                  if (isTypePreview) {
-                    setPreview(null, null);
-                  } else {
-                    setPreview(course.id, type);
-                  }
-                }}
-                className={cn(
-                  "p-0.5 rounded transition-colors",
-                  isTypePreview
-                    ? "text-primary bg-primary/10"
-                    : "text-muted-foreground hover:text-primary",
-                )}
-              >
-                <Eye className="h-3 w-3" />
-              </button>
-            </Hint>
           </div>
         );
       })}

--- a/packages/sogrim-app-v2/src/components/timetable/selected-courses-panel.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/selected-courses-panel.tsx
@@ -5,7 +5,7 @@ import { useProviderUpdates } from "@/hooks/use-api-provider";
 import { getCourseColor } from "@/lib/timetable-colors";
 import { useUiStore } from "@/stores/ui-store";
 import { GroupSelector } from "./group-selector";
-import { Trash2, BookOpen, Search, ChevronDown } from "lucide-react";
+import { Trash2, BookOpen, Search, ChevronDown, Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function SelectedCoursesPanel() {
@@ -14,6 +14,8 @@ export function SelectedCoursesPanel() {
   const removeCourse = useTimetableStore((s) => s.removeCourse);
   const setSearchOpen = useTimetableStore((s) => s.setSearchOpen);
   const setDetailCourse = useTimetableStore((s) => s.setDetailCourse);
+  const hiddenCourseIds = useTimetableStore((s) => s.hiddenCourseIds);
+  const toggleCourseHidden = useTimetableStore((s) => s.toggleCourseHidden);
   const theme = useUiStore((s) => s.theme);
   const isDark = theme === "dark";
 
@@ -81,6 +83,7 @@ export function SelectedCoursesPanel() {
             const color = getCourseColor(colorIndex);
             const bgColor = isDark ? color.bgDark : color.bg;
             const isExpanded = !collapsedIds.has(selection.courseId);
+            const isHidden = hiddenCourseIds.has(selection.courseId);
 
             return (
               <div
@@ -98,15 +101,39 @@ export function SelectedCoursesPanel() {
                 >
                   {/* Color dot */}
                   <div
-                    className="w-3 h-3 rounded-full shrink-0"
+                    className={cn(
+                      "w-3 h-3 rounded-full shrink-0 transition-opacity",
+                      isHidden && "opacity-30",
+                    )}
                     style={{ backgroundColor: bgColor }}
                   />
 
                   {/* Course name + credits */}
-                  <div className="flex-1 min-w-0">
+                  <div className={cn("flex-1 min-w-0 transition-opacity", isHidden && "opacity-40")}>
                     <div className="text-sm font-medium truncate">{course.name}</div>
                     <div className="text-[0.7rem] text-muted-foreground">{course.credit} נק״ז</div>
                   </div>
+
+                  {/* Hide/show on the calendar */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleCourseHidden(selection.courseId);
+                    }}
+                    aria-label={isHidden ? "הצג במערכת השעות" : "הסתר ממערכת השעות"}
+                    className={cn(
+                      "p-1 rounded shrink-0 transition-opacity",
+                      isHidden
+                        ? "opacity-100 text-primary hover:bg-primary/10"
+                        : "opacity-50 hover:opacity-100 text-muted-foreground hover:bg-accent",
+                    )}
+                  >
+                    {isHidden ? (
+                      <EyeOff className="h-3.5 w-3.5" />
+                    ) : (
+                      <Eye className="h-3.5 w-3.5" />
+                    )}
+                  </button>
 
                   {/* Delete — always visible */}
                   <button

--- a/packages/sogrim-app-v2/src/components/timetable/timetable-page.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/timetable-page.tsx
@@ -64,13 +64,12 @@ function TimetableContent() {
     }
   }, [currentSemester, createDraft]);
 
-  const previewingCourse = useTimetableStore((s) => s.previewingCourse);
-  const previewingType = useTimetableStore((s) => s.previewingType);
+  const hiddenCourseIds = useTimetableStore((s) => s.hiddenCourseIds);
 
   const activeDraft = drafts.find((d) => d.id === activeDraftId);
   const events = useMemo(
-    () => resolveEvents(activeDraft, previewingCourse, previewingType),
-    [activeDraft, previewingCourse, previewingType, providerVersion],
+    () => resolveEvents(activeDraft, hiddenCourseIds),
+    [activeDraft, hiddenCourseIds, providerVersion],
   );
 
   const hasCourses = (activeDraft?.courses.length ?? 0) > 0;

--- a/packages/sogrim-app-v2/src/components/timetable/week-grid.tsx
+++ b/packages/sogrim-app-v2/src/components/timetable/week-grid.tsx
@@ -8,12 +8,13 @@ import {
   totalSlots,
   computeVisibleRange,
   timeToRow,
-  timeSpanRows,
   parseTime,
   hasFridayEvents,
+  layoutEvents,
 } from "@/lib/timetable-utils";
 import { CourseBlock } from "./course-block";
 import { CustomEventDialog } from "./custom-event-dialog";
+import { chosenEvents } from "@/lib/timetable-conflicts";
 import { cn } from "@/lib/utils";
 
 interface WeekGridProps {
@@ -29,7 +30,7 @@ export function WeekGrid({ events, compact = false }: WeekGridProps) {
 
   // Base range from real (non-preview) events — snaps back when courses are removed.
   // Preview events can temporarily expand the range but don't persist.
-  const realEvents = useMemo(() => events.filter((e) => !e.isPreview), [events]);
+  const realEvents = useMemo(() => chosenEvents(events), [events]);
   const baseRange = useMemo(() => computeVisibleRange(realEvents), [realEvents]);
   const fullRange = computeVisibleRange(events);
   const startHour = Math.min(baseRange.startHour, fullRange.startHour);
@@ -192,73 +193,6 @@ export function WeekGrid({ events, compact = false }: WeekGridProps) {
       />
     </>
   );
-}
-
-/** Lay out events into non-overlapping columns (like FullCalendar's slotEventOverlap:false).
- *  Returns positioned events with left/width percentages within the column. */
-function layoutEvents(
-  events: TimetableEvent[],
-  startHour: number,
-  slotCount: number,
-): { event: TimetableEvent; topPct: number; heightPct: number; leftPct: number; widthPct: number }[] {
-  if (events.length === 0) return [];
-
-  // Sort by start time, then by duration (longer first for stable layout).
-  const sorted = [...events].sort((a, b) => {
-    const aStart = parseTime(a.startTime);
-    const bStart = parseTime(b.startTime);
-    if (aStart !== bStart) return aStart - bStart;
-    return parseTime(b.endTime) - parseTime(a.endTime);
-  });
-
-  // Assign each event to a column, tracking end times per column.
-  const columns: number[] = []; // end time (in minutes) of each column
-  const eventCols: number[] = [];
-  const eventGroups: number[] = []; // which overlap group each event belongs to
-  const groupMaxCols: number[] = []; // max columns used per group
-
-  let currentGroupEnd = 0;
-  let groupIndex = -1;
-
-  for (let i = 0; i < sorted.length; i++) {
-    const ev = sorted[i];
-    const evStart = parseTime(ev.startTime);
-    const evEnd = parseTime(ev.endTime);
-
-    // Check if this event starts a new non-overlapping group
-    if (evStart >= currentGroupEnd) {
-      groupIndex++;
-      currentGroupEnd = evEnd;
-      columns.length = 0; // reset columns for new group
-    } else {
-      currentGroupEnd = Math.max(currentGroupEnd, evEnd);
-    }
-
-    // Find first column where the event fits (no overlap)
-    let col = 0;
-    while (col < columns.length && columns[col] > evStart) {
-      col++;
-    }
-    columns[col] = evEnd;
-    eventCols[i] = col;
-    eventGroups[i] = groupIndex;
-    groupMaxCols[groupIndex] = Math.max(groupMaxCols[groupIndex] ?? 0, col + 1);
-  }
-
-  return sorted.map((event, i) => {
-    const row = timeToRow(event.startTime, startHour);
-    const span = timeSpanRows(event.startTime, event.endTime);
-    const totalCols = groupMaxCols[eventGroups[i]];
-    const col = eventCols[i];
-
-    return {
-      event,
-      topPct: (row / slotCount) * 100,
-      heightPct: (span / slotCount) * 100,
-      leftPct: (col / totalCols) * 100,
-      widthPct: (1 / totalCols) * 100,
-    };
-  });
 }
 
 interface DayColumnProps {

--- a/packages/sogrim-app-v2/src/components/ui/hint.tsx
+++ b/packages/sogrim-app-v2/src/components/ui/hint.tsx
@@ -17,6 +17,35 @@ export interface HintProps {
   className?: string;
 }
 
+/** How long a tapped hint stays up before hiding itself. */
+const TOUCH_AUTO_HIDE_MS = 2500;
+
+const noop = () => {};
+
+/** True when the primary pointer can't hover — phones and tablets. */
+function useCoarsePointer(): boolean {
+  const query = "(hover: none)";
+  const [coarse, setCoarse] = React.useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia(query).matches,
+  );
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mql = window.matchMedia(query);
+    setCoarse(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setCoarse(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return coarse;
+}
+
 /**
  * Hover hint built on the app Tooltip primitive. Use this instead of the
  * native `title` attribute, which is unstyled and only appears after a
@@ -25,17 +54,66 @@ export interface HintProps {
  * The single child becomes the trigger (via `asChild`), so it must be one
  * element that forwards a ref and props (a DOM element or a component that
  * spreads props onto one).
+ *
+ * On touch devices there is no hover, and Radix tooltips never open from a
+ * tap, so the hint would be unreachable. There we drive `open` ourselves: a
+ * tap shows the hint (the child's own onClick still runs), and it hides on
+ * the next tap, on scroll, or after a short timeout.
  */
 export function Hint({ label, children, side = "top", align, className }: HintProps) {
+  const isTouch = useCoarsePointer();
+  const [touchOpen, setTouchOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isTouch || !touchOpen) return;
+    const close = () => setTouchOpen(false);
+    // Registered after the tap that opened the hint, so it only reacts to the next one.
+    const timer = window.setTimeout(close, TOUCH_AUTO_HIDE_MS);
+    window.addEventListener("pointerdown", close, true);
+    window.addEventListener("scroll", close, true);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("pointerdown", close, true);
+      window.removeEventListener("scroll", close, true);
+    };
+  }, [isTouch, touchOpen]);
+
   if (label === null || label === undefined || label === "") {
     return <>{children}</>;
   }
+
+  const content = (
+    <TooltipContent
+      side={side}
+      align={align}
+      className={cn(
+        "max-w-xs text-right",
+        isTouch && "pointer-events-none",
+        className,
+      )}
+    >
+      {label}
+    </TooltipContent>
+  );
+
+  if (isTouch) {
+    return (
+      // Radix's own open/close requests are ignored here — a tap fires both
+      // pointerdown and click, and Radix closes on each, which would undo the
+      // open we just asked for.
+      <Tooltip open={touchOpen} onOpenChange={noop}>
+        <TooltipTrigger asChild onClick={() => setTouchOpen(true)}>
+          {children}
+        </TooltipTrigger>
+        {content}
+      </Tooltip>
+    );
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent side={side} align={align} className={cn("max-w-xs text-right", className)}>
-        {label}
-      </TooltipContent>
+      {content}
     </Tooltip>
   );
 }

--- a/packages/sogrim-app-v2/src/lib/timetable-conflicts.ts
+++ b/packages/sogrim-app-v2/src/lib/timetable-conflicts.ts
@@ -23,6 +23,12 @@ function timesOverlap(
   return sA < eB && sB < eA;
 }
 
+/** Events the user has actually chosen. Ghost previews of unselected groups are
+ *  excluded — those are only shown as options and must not count as conflicts. */
+export function chosenEvents(events: TimetableEvent[]): TimetableEvent[] {
+  return events.filter((e) => !e.isPreview);
+}
+
 /** Find all conflicting pairs among timetable events */
 export function findConflicts(events: TimetableEvent[]): Conflict[] {
   const conflicts: Conflict[] = [];

--- a/packages/sogrim-app-v2/src/lib/timetable-utils.ts
+++ b/packages/sogrim-app-v2/src/lib/timetable-utils.ts
@@ -1,4 +1,4 @@
-import type { Day, LessonType } from "@/types/timetable";
+import type { Day, LessonType, TimetableEvent } from "@/types/timetable";
 
 /** Day names in Hebrew, indexed by Day (0=Sunday) */
 export const DAY_NAMES: Record<Day, string> = {
@@ -97,7 +97,7 @@ export function timeToRow(time: string, startHour?: number): number {
 }
 
 /** Number of grid rows a time range spans */
-export function timeSpanRows(startTime: string, endTime: string): number {
+function timeSpanRows(startTime: string, endTime: string): number {
   const start = parseTime(startTime);
   const end = parseTime(endTime);
   return (end - start) / SLOT_MINUTES;
@@ -129,5 +129,81 @@ export function hasFridayEvents(events: { day: number }[]): boolean {
 /** Generate a unique draft ID */
 export function generateDraftId(): string {
   return `draft-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/** A single event positioned within a day column, as percentages of the column box. */
+export interface PositionedEvent {
+  event: TimetableEvent;
+  topPct: number;
+  heightPct: number;
+  leftPct: number;
+  widthPct: number;
+}
+
+/** Lay out events into non-overlapping columns (like FullCalendar's slotEventOverlap:false).
+ *  Returns positioned events with left/width percentages within the column. */
+export function layoutEvents(
+  events: TimetableEvent[],
+  startHour: number,
+  slotCount: number,
+): PositionedEvent[] {
+  if (events.length === 0) return [];
+
+  // Sort by start time, then by duration (longer first for stable layout).
+  const sorted = [...events].sort((a, b) => {
+    const aStart = parseTime(a.startTime);
+    const bStart = parseTime(b.startTime);
+    if (aStart !== bStart) return aStart - bStart;
+    return parseTime(b.endTime) - parseTime(a.endTime);
+  });
+
+  // Assign each event to a column, tracking end times per column.
+  const columns: number[] = []; // end time (in minutes) of each column
+  const eventCols: number[] = [];
+  const eventGroups: number[] = []; // which overlap group each event belongs to
+  const groupMaxCols: number[] = []; // max columns used per group
+
+  let currentGroupEnd = 0;
+  let groupIndex = -1;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const ev = sorted[i];
+    const evStart = parseTime(ev.startTime);
+    const evEnd = parseTime(ev.endTime);
+
+    // Check if this event starts a new non-overlapping group
+    if (evStart >= currentGroupEnd) {
+      groupIndex++;
+      currentGroupEnd = evEnd;
+      columns.length = 0; // reset columns for new group
+    } else {
+      currentGroupEnd = Math.max(currentGroupEnd, evEnd);
+    }
+
+    // Find first column where the event fits (no overlap)
+    let col = 0;
+    while (col < columns.length && columns[col] > evStart) {
+      col++;
+    }
+    columns[col] = evEnd;
+    eventCols[i] = col;
+    eventGroups[i] = groupIndex;
+    groupMaxCols[groupIndex] = Math.max(groupMaxCols[groupIndex] ?? 0, col + 1);
+  }
+
+  return sorted.map((event, i) => {
+    const row = timeToRow(event.startTime, startHour);
+    const span = timeSpanRows(event.startTime, event.endTime);
+    const totalCols = groupMaxCols[eventGroups[i]];
+    const col = eventCols[i];
+
+    return {
+      event,
+      topPct: (row / slotCount) * 100,
+      heightPct: (span / slotCount) * 100,
+      leftPct: (col / totalCols) * 100,
+      widthPct: (1 / totalCols) * 100,
+    };
+  });
 }
 

--- a/packages/sogrim-app-v2/src/stores/timetable-store.ts
+++ b/packages/sogrim-app-v2/src/stores/timetable-store.ts
@@ -11,7 +11,7 @@ import type {
 } from "@/types/timetable";
 import { getProvider } from "@/data/course-schedule-provider";
 import { generateDraftId } from "@/lib/timetable-utils";
-import { getConflictingEventKeys, eventKey } from "@/lib/timetable-conflicts";
+import { chosenEvents, getConflictingEventKeys, eventKey } from "@/lib/timetable-conflicts";
 import { semesterKey, semestersEqual } from "@/lib/semester-utils";
 import type { AcademicSemester } from "@/types/api";
 
@@ -20,9 +20,8 @@ interface TimetableState {
   viewMode: ViewMode;
   selectedDay: Day;
   searchOpen: boolean;
-  previewingCourse: string | null;
-  previewingType: LessonType | null;
   detailCourseId: string | null;
+  hiddenCourseIds: Set<string>;
 
   // Persistent state (saved to backend)
   currentSemester: AcademicSemester | null;
@@ -40,8 +39,8 @@ interface TimetableState {
   setViewMode: (mode: ViewMode) => void;
   setSelectedDay: (day: Day) => void;
   setSearchOpen: (open: boolean) => void;
-  setPreview: (courseId: string | null, type: LessonType | null) => void;
   setDetailCourse: (courseId: string | null) => void;
+  toggleCourseHidden: (courseId: string) => void;
 
   // Actions: semester
   setSemester: (semester: AcademicSemester) => void;
@@ -86,9 +85,8 @@ export const useTimetableStore = create<TimetableState>()(
       viewMode: "week",
       selectedDay: 0,
       searchOpen: false,
-      previewingCourse: null,
-      previewingType: null,
       detailCourseId: null,
+      hiddenCourseIds: new Set(),
       currentSemester: null,
       drafts: [],
       activeDraftId: null,
@@ -101,8 +99,14 @@ export const useTimetableStore = create<TimetableState>()(
       setViewMode: (mode) => set({ viewMode: mode }),
       setSelectedDay: (day) => set({ selectedDay: day }),
       setSearchOpen: (open) => set({ searchOpen: open }),
-      setPreview: (courseId, type) => set({ previewingCourse: courseId, previewingType: type }),
       setDetailCourse: (courseId) => set({ detailCourseId: courseId }),
+
+      toggleCourseHidden: (courseId) => {
+        const next = new Set(get().hiddenCourseIds);
+        if (next.has(courseId)) next.delete(courseId);
+        else next.add(courseId);
+        set({ hiddenCourseIds: next });
+      },
 
       setSemester: (semester) => {
         const state = get();
@@ -188,7 +192,11 @@ export const useTimetableStore = create<TimetableState>()(
         const draft = getActiveDraft(state);
         if (!draft) return;
 
+        const nextHidden = new Set(state.hiddenCourseIds);
+        nextHidden.delete(courseId);
+
         set({
+          hiddenCourseIds: nextHidden,
           drafts: updateDraft(state.drafts, draft.id, (d) => ({
             courses: d.courses.filter((c) => c.courseId !== courseId),
             isPublished: false,
@@ -215,8 +223,6 @@ export const useTimetableStore = create<TimetableState>()(
             }),
             isPublished: false,
           })),
-          previewingCourse: null,
-          previewingType: null,
         });
       },
 
@@ -266,12 +272,12 @@ export const useTimetableStore = create<TimetableState>()(
 
 /**
  * Resolve current draft's course selections into renderable TimetableEvents.
- * Includes ghost preview events when previewing group alternatives.
+ * Unselected lesson types render all their groups as ghost preview events.
+ * Courses in `hiddenCourseIds` are skipped entirely.
  */
 export function resolveEvents(
   draft: TimetableDraft | undefined,
-  previewingCourse?: string | null,
-  previewingType?: LessonType | null,
+  hiddenCourseIds?: Set<string> | null,
 ): TimetableEvent[] {
   if (!draft) return [];
 
@@ -279,12 +285,11 @@ export function resolveEvents(
   const events: TimetableEvent[] = [];
 
   draft.courses.forEach((selection, courseIndex) => {
+    if (hiddenCourseIds?.has(selection.courseId)) return;
     const course = provider.getCourse(selection.courseId);
     if (!course) return;
 
     const colorIndex = courseIndex;
-    const isPreviewTarget =
-      previewingCourse === course.id && previewingType != null;
 
     const typeSet = new Set(course.groups.map((g) => g.type));
 
@@ -312,30 +317,6 @@ export function resolveEvents(
             colorIndex,
             hasConflict: false,
           });
-        }
-
-        if (isPreviewTarget && previewingType === type) {
-          for (const altGroup of typeGroups.filter((g) => g.id !== selectedGroupId)) {
-            const altKindLabel = `${altGroup.kindLabel} ${altGroup.id.split("-")[0].split("/").map((n) => n.replace(/^0+/, "") || "0").join("/")}`;
-            for (const lesson of altGroup.lessons) {
-              events.push({
-                courseId: course.id,
-                courseName: course.name,
-                type: altGroup.type,
-                kindLabel: altKindLabel,
-                groupId: altGroup.id,
-                day: lesson.day,
-                startTime: lesson.startTime,
-                endTime: lesson.endTime,
-                building: lesson.building,
-                room: lesson.room,
-                instructor: lesson.instructor,
-                colorIndex,
-                hasConflict: false,
-                isPreview: true,
-              });
-            }
-          }
         }
       } else {
         for (const group of typeGroups) {
@@ -383,8 +364,7 @@ export function resolveEvents(
     });
   });
 
-  const realEvents = events.filter((e) => !e.isPreview);
-  const conflictKeys = getConflictingEventKeys(realEvents);
+  const conflictKeys = getConflictingEventKeys(chosenEvents(events));
   return events.map((e) => ({
     ...e,
     hasConflict: e.isPreview ? false : conflictKeys.has(eventKey(e)),


### PR DESCRIPTION
…fixes

Timetable
- Replace the group "preview alternatives" feature with a per-course hide/show toggle in the selected-courses panel. Unselected lesson types now render all their groups as ghost options instead.
- Day view laid every block out at full width, so overlapping lessons stacked and only one was visible. Extract the week grid's column-packing helper into `layoutEvents` in timetable-utils and reuse it in day view, so both grids place overlaps side-by-side identically.
- The conflict badge counted collisions between ghost preview blocks, i.e. groups the user never chose, inflating the total. Add `chosenEvents()` as the single source of truth for "what the user actually picked" and route the badge, block highlighting, and hour-range logic through it.

Mobile
- פטורים וזיכויים used a 12-column grid at every breakpoint, leaving ~20px per column on a phone, so the status badge overlapped the delete column. Render a two-line row below `sm` and keep the table row above it, with the badge and delete button shared between both layouts.
- Hidden-until-hover actions were unreachable on touch: renaming or deleting a timetable draft was impossible on a phone. Reveal them via the `pointer-coarse` variant.
- Radix tooltips never open from a tap, so every `Hint` was dead on touch. Drive `open` ourselves on coarse pointers: a tap shows the hint and it hides on the next tap, on scroll, or after a timeout.
- The modified-status strip reserved its full height even when hidden, leaving a large blank gap between the header and the degree stats. Drop it entirely on mobile when idle, keep reserving it on desktop, and give the banner a full-bleed treatment so it meets the header.